### PR TITLE
Homepage hero FED

### DIFF
--- a/cdhweb/pages/templates/cdhpages/home_page.html
+++ b/cdhweb/pages/templates/cdhpages/home_page.html
@@ -6,19 +6,9 @@
 
 {% block content %} {# add a class to main content for home-page specific styles #}
 
-
-<h2>Homepage hero</h2>
-<div>{{ self.title}}</div>
-<div>{{ self.summary }}</div>
-{% if self.hero_image %}
-{% image self.hero_image width-400 as image %}
-<img src="{{ image.url }}" alt="{{ image.title }}" />
-{% endif %}
-
-<div class="homepage{% if updates %} with-carousel{% endif %}">
+{% include 'includes/home_hero.html' %}
 
 {{ block.super }}
-</div>
 
 {% endblock %}
 

--- a/cdhweb/pages/templates/includes/home_hero.html
+++ b/cdhweb/pages/templates/includes/home_hero.html
@@ -8,10 +8,7 @@
                 <p>{{ self.summary }}</p>
             {% endif %}
         </div>
-        <div class="hero-home__box">
-            <div class="hero-home__box-bit hero-home__box-bit--right"></div>
-            <div class="hero-home__box-bit hero-home__box-bit--bottom"></div>
-        </div>
+        <div class="hero-home__box"></div>
     </div>
     {# In the browser, image *heights* are capped. So we make them be high-res based on that dimension. #}
     {% image self.hero_image height-624 as img_sm %}

--- a/cdhweb/pages/templates/includes/home_hero.html
+++ b/cdhweb/pages/templates/includes/home_hero.html
@@ -1,0 +1,27 @@
+{% load wagtailcore_tags wagtailimages_tags l10n %}
+
+<div class="home-hero content-width grid-standard">
+    <div class="home-hero__content">
+        <div class="home-hero__content-text">    
+            <h1>{{ self.title}}</h1>
+            {% if self.summary %}
+                <p>{{ self.summary }}</p>
+            {% endif %}
+        </div>
+        <div class="hero-home__box">
+            <div class="hero-home__box-bit hero-home__box-bit--right"></div>
+            <div class="hero-home__box-bit hero-home__box-bit--bottom"></div>
+        </div>
+    </div>
+    {# In the browser, image *heights* are capped. So we make them be high-res based on that dimension. #}
+    {% image self.hero_image height-624 as img_sm %}
+    {% image self.hero_image height-996 as img_lg %}
+    <img src="{{ img_sm.url }}" 
+        class="home-hero__img"
+        alt="{{ img_sm.alt }}"
+        srcset="{{ img_sm.url }} {{ img_sm.width|unlocalize }}w,
+                {{ img_sm.url }} {{ img_sm.width|unlocalize }}w"
+        sizes="(min-width: 500px) {{ img_sm.width|unlocalize }}px, 100vw"
+    />
+    
+</div>

--- a/cdhweb/static_src/global/components/home-hero.scss
+++ b/cdhweb/static_src/global/components/home-hero.scss
@@ -1,0 +1,153 @@
+// has `.grid-standard`
+.home-hero {
+  --bg-box-border-width: 8px;
+  --total-border-width: calc(var(--bg-box-border-width) * 2);
+
+  // Spacing around the text inside the box:
+  --bg-box-x-pad: 24px;
+  --bg-box-y-pad: 24px;
+  --space-below-box: 56px;
+
+  // TODO might need fine-tuning later. Tricky to get this value in figma.
+  --image-overlap: -30px;
+
+  // Needs a big bottom space due to absolute-positioned 3d box shape.
+  margin-block-end: calc(
+    var(--space-below-box) + var(--bg-box-y-pad) + var(--total-border-width)
+  );
+
+  // i = image
+  // c = content
+  grid-template-areas:
+    'i i i i i i i i i i i i'
+    '. c c c c c c c c c . .';
+
+  @include sm {
+    --space-below-box: 80px;
+  }
+
+  @include md {
+    --space-below-box: 104px;
+
+    grid-template-areas:
+      'i i i i i i i i i i i i'
+      '. c c c c c c c . . . .';
+  }
+  @include lg {
+    --bg-box-x-pad: 56px;
+    --bg-box-y-pad: 40px;
+
+    grid-template-areas:
+      'i i i i i i i i i i i i'
+      '. . c c c c c c . . . .';
+  }
+
+  @include xl {
+    grid-template-areas:
+      '. i i i i i i i i i i .'
+      '. . c c c c c . . . . .';
+  }
+
+  @include xxl {
+    --space-below-box: 136px;
+  }
+}
+
+.home-hero__content {
+  grid-area: c;
+  position: relative;
+  transform: translateY(var(--image-overlap));
+}
+
+.home-hero__content-text {
+  position: relative;
+  z-index: 1; // in front of white 3d box
+
+  :where(h1) {
+    margin: 0 0 8px;
+    @include lg {
+      margin-block-end: 16px;
+    }
+  }
+  :where(p) {
+    margin: 0;
+    font-size: px2rem(24);
+    line-height: 1.5;
+  }
+}
+
+// fancy 3d-lookin' background box
+.hero-home__box {
+  position: absolute;
+  background-color: var(--color-white);
+  // Using an inset box shadow instead of border because it makes positioning the 3d sides MUCH simpler.
+  box-shadow: 0 0 0 var(--bg-box-border-width) var(--color-brand-100) inset;
+  top: 0;
+  width: calc(100% + var(--bg-box-x-pad) * 2);
+  height: calc(100% + var(--bg-box-y-pad) * 2);
+  transform: translate(
+    calc(-1 * var(--bg-box-x-pad)),
+    calc(-1 * var(--bg-box-y-pad))
+  );
+  pointer-events: none;
+}
+
+// more fancy 3d-lookin' background box: the raised sides
+.hero-home__box-bit {
+  --box-3d-side-size: 18px;
+
+  background-color: var(--color-brand-100);
+  position: absolute;
+  transform-origin: top left;
+
+  @include md {
+    --box-3d-side-size: 56px;
+  }
+}
+
+.hero-home__box-bit--right {
+  width: var(--box-3d-side-size);
+  height: 100%;
+  right: calc(-1 * var(--box-3d-side-size));
+  top: 0;
+  transform: skew(0, 45deg);
+}
+
+.hero-home__box-bit--bottom {
+  // The +1px is to stop a pixel rounding bug where a diagonal
+  // transparent line shows where the two 3d box bits meet.
+  // To fix this, we need to make one of the 3d bits (the bottom) 1px wider.
+  // BUT that causes it to have an extra li'l pointy pixel sticking out the side.
+  // So to stop THAT happening, we use clip-path to lop that bottom-right pixel off.
+  width: calc(100% + 1px);
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 1px),
+    calc(100% - 1px) 100%,
+    0 100%
+  );
+
+  height: var(--box-3d-side-size);
+  left: 0;
+  bottom: calc(-1 * var(--box-3d-side-size));
+  transform: skew(45deg, 0);
+}
+
+.home-hero__img {
+  grid-area: i;
+  @include break-grid;
+
+  @include xl {
+    @include undo-break-grid;
+  }
+
+  :where(img) {
+    object-fit: cover;
+    height: 312px;
+
+    @include sm {
+      height: 498px;
+    }
+  }
+}

--- a/cdhweb/static_src/global/components/home-hero.scss
+++ b/cdhweb/static_src/global/components/home-hero.scss
@@ -78,10 +78,9 @@
 
 // fancy 3d-lookin' background box
 .hero-home__box {
+  --box-3d-side-size: 18px;
+
   position: absolute;
-  background-color: var(--color-white);
-  // Using an inset box shadow instead of border because it makes positioning the 3d sides MUCH simpler.
-  box-shadow: 0 0 0 var(--bg-box-border-width) var(--color-brand-100) inset;
   top: 0;
   width: calc(100% + var(--bg-box-x-pad) * 2);
   height: calc(100% + var(--bg-box-y-pad) * 2);
@@ -89,49 +88,41 @@
     calc(-1 * var(--bg-box-x-pad)),
     calc(-1 * var(--bg-box-y-pad))
   );
-  pointer-events: none;
-}
-
-// more fancy 3d-lookin' background box: the raised sides
-.hero-home__box-bit {
-  --box-3d-side-size: 18px;
-
-  background-color: var(--color-brand-100);
-  position: absolute;
-  transform-origin: top left;
 
   @include md {
     --box-3d-side-size: 56px;
   }
-}
 
-.hero-home__box-bit--right {
-  width: var(--box-3d-side-size);
-  height: 100%;
-  right: calc(-1 * var(--box-3d-side-size));
-  top: 0;
-  transform: skew(0, 45deg);
-}
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+  }
 
-.hero-home__box-bit--bottom {
-  // The +1px is to stop a pixel rounding bug where a diagonal
-  // transparent line shows where the two 3d box bits meet.
-  // To fix this, we need to make one of the 3d bits (the bottom) 1px wider.
-  // BUT that causes it to have an extra li'l pointy pixel sticking out the side.
-  // So to stop THAT happening, we use clip-path to lop that bottom-right pixel off.
-  width: calc(100% + 1px);
-  clip-path: polygon(
-    0 0,
-    100% 0,
-    100% calc(100% - 1px),
-    calc(100% - 1px) 100%,
-    0 100%
-  );
+  // white box with border
+  &::before {
+    width: 100%;
+    height: 100%;
+    background-color: var(--color-white);
+    border: var(--bg-box-border-width) solid var(--color-brand-100);
+  }
 
-  height: var(--box-3d-side-size);
-  left: 0;
-  bottom: calc(-1 * var(--box-3d-side-size));
-  transform: skew(45deg, 0);
+  // fancy 3d-lookin' box sides (just a rectangle with the top-right and bottom-left corners removed)
+  &::after {
+    z-index: -1; // behind white content box
+    width: calc(100% + var(--box-3d-side-size));
+    height: calc(100% + var(--box-3d-side-size));
+    background-color: var(--color-brand-100);
+
+    clip-path: polygon(
+      calc(100% - var(--box-3d-side-size)) 0,
+      100% var(--box-3d-side-size),
+      100% 100%,
+      var(--box-3d-side-size) 100%,
+      0 calc(100% - var(--box-3d-side-size)),
+      0 0
+    );
+  }
 }
 
 .home-hero__img {

--- a/cdhweb/static_src/global/mixins/grid.scss
+++ b/cdhweb/static_src/global/mixins/grid.scss
@@ -40,3 +40,8 @@
   width: calc(100% + var(--page-gutter));
   margin-right: calc(#{var(--page-gutter)} * -1);
 }
+@mixin undo-break-grid {
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
+}

--- a/cdhweb/static_src/global/mixins/typography.scss
+++ b/cdhweb/static_src/global/mixins/typography.scss
@@ -2,14 +2,17 @@
 
 // These mixins are intended to allow you to style (e.g.) an h2 to look like (e.g.) an h3.
 @mixin h1 {
-  font-size: px2rem(40);
-  line-height: 1.2;
-  font-weight: bold;
+  font-size: px2rem(36);
+  line-height: 1;
+  font-weight: 900;
   text-wrap: balance;
 
+  @include md {
+    font-size: px2rem(48);
+  }
+
   @include xl {
-    font-size: px2rem(64);
-    line-height: 1.12;
+    font-size: px2rem(56);
   }
 }
 

--- a/cdhweb/static_src/styles.scss
+++ b/cdhweb/static_src/styles.scss
@@ -44,7 +44,7 @@
 @import './global/components/forms.scss';
 
 // All other components go here:
-// e.g. footer.scss, video-block.scss, etc
+@import './global/components/home-hero.scss';
 
 // Utility classes. This should go last.
 @import './global/utilities';


### PR DESCRIPTION
This introduces a 3d box thing, which will be used through the site later on. When that happens, this may need refactoring to helper classes or mixins... maybe. The tricky part about _that_ is that in this case the box is absolute-positioned around the text, because the text needs to align to the content grid. But in future instances, it's the box needs to _not_ be absolute-positioned because _it_ needs to align to the grid. But that's a later problem.

Anyway here's the homepage hero:
<img width="1009" alt="Screenshot 2024-05-13 at 9 34 35 AM" src="https://github.com/springload/cdh-web/assets/1134713/c35de324-3fcc-4c93-a68d-27386dc80ee6">

Mobile: 
<img width="388" alt="Screenshot 2024-05-13 at 9 34 23 AM" src="https://github.com/springload/cdh-web/assets/1134713/0e0432ba-693c-4c7e-b0a7-af8cf7c087c2">


Illustrating that it is the text that aligns to the grid, not the box:
<img width="1002" alt="Screenshot 2024-05-13 at 9 42 19 AM" src="https://github.com/springload/cdh-web/assets/1134713/d4639bcb-c8f7-423a-a596-2c6262ec156d">

Here's one of the 3d side shapes:
<img width="1368" alt="Screenshot 2024-05-13 at 9 35 09 AM" src="https://github.com/springload/cdh-web/assets/1134713/a91c8d7d-c11b-407c-b5de-e16a921c167c">
