### PR TITLE
Pull quote FED

### DIFF
--- a/cdhweb/pages/templates/cdhpages/blocks/block_quote.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/block_quote.html
@@ -1,3 +1,3 @@
 {% load wagtailcore_tags %}
 
-<p>{{ self.quote|richtext }}</p>
+<div class="block-quote">{{ self.quote|richtext }}</div>

--- a/cdhweb/pages/templates/cdhpages/blocks/pull_quote.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/pull_quote.html
@@ -1,6 +1,12 @@
 {% load wagtailcore_tags %}
 
-<div>{{ self.quote|richtext }}</div>
-{% if self.attribution %}
-    <div>{{ self.attribution|richtext }} </div>
-{% endif %}
+<blockquote class="pull-quote">
+    <div class="pull-quote__quote rich-text">{{ self.quote|richtext }}</div>
+    {% if self.attribution %}
+        {% comment %}
+            NOTE: deliberately not using a `<cite>` here, as the CMS field is richtext, 
+                and `p` is an invalid child of `cite`
+        {% endcomment %}
+        <div class="pull-quote__citation rich-text">{{ self.attribution|richtext }}</div>
+    {% endif %}
+</blockquote>

--- a/cdhweb/pages/templates/cdhpages/blocks/pull_quote.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/pull_quote.html
@@ -1,12 +1,10 @@
 {% load wagtailcore_tags %}
 
-<blockquote class="pull-quote">
-    <div class="pull-quote__quote rich-text">{{ self.quote|richtext }}</div>
+<figure class="pull-quote">
+    <blockquote>
+        <div class="pull-quote__quote rich-text">{{ self.quote|richtext }}</div>
+    </blockquote>
     {% if self.attribution %}
-        {% comment %}
-            NOTE: deliberately not using a `<cite>` here, as the CMS field is richtext, 
-                and `p` is an invalid child of `cite`
-        {% endcomment %}
-        <div class="pull-quote__citation rich-text">{{ self.attribution|richtext }}</div>
+        <figcaption class="pull-quote__citation rich-text">{{ self.attribution|richtext }}</figcaption>
     {% endif %}
-</blockquote>
+</figure>

--- a/cdhweb/static_src/global/components/block-quote.scss
+++ b/cdhweb/static_src/global/components/block-quote.scss
@@ -1,0 +1,3 @@
+.block-quote {
+  @include outdented-line-block;
+}

--- a/cdhweb/static_src/global/components/note.scss
+++ b/cdhweb/static_src/global/components/note.scss
@@ -1,21 +1,5 @@
 .note {
-  position: relative;
-  padding-inline-start: 32px;
-
-  @include md {
-    padding-inline-start: 0;
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    transform: translateX(calc(-1 * var(--content-outdent)));
-    width: 8px;
-    height: 100%;
-    background-color: var(--color-brand-100);
-  }
+  @include outdented-line-block;
 
   :where(h2) {
     margin-block-end: 8px;

--- a/cdhweb/static_src/global/components/pull-quote.scss
+++ b/cdhweb/static_src/global/components/pull-quote.scss
@@ -1,0 +1,33 @@
+.pull-quote {
+  @include outdented-line-block;
+}
+
+.pull-quote__quote {
+  font-size: px2rem(24);
+  line-height: 1.25;
+
+  @include sm {
+    font-size: px2rem(32);
+  }
+}
+
+.pull-quote__citation {
+  font-style: italic;
+  margin-block-start: 16px;
+  font-size: px2rem(20);
+
+  // for endash pseudo content:
+  position: relative;
+  padding-left: 1.5ch;
+
+  @include sm {
+    margin-block-start: 24px;
+  }
+
+  &::before {
+    content: '–';
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+}

--- a/cdhweb/static_src/global/mixins.scss
+++ b/cdhweb/static_src/global/mixins.scss
@@ -4,3 +4,4 @@
 @import './mixins/typography';
 @import './mixins/btn';
 @import './mixins/visibility';
+@import './mixins/outdented-line-block';

--- a/cdhweb/static_src/global/mixins/outdented-line-block.scss
+++ b/cdhweb/static_src/global/mixins/outdented-line-block.scss
@@ -1,0 +1,19 @@
+@mixin outdented-line-block {
+  position: relative;
+  padding-inline-start: 32px;
+
+  @include md {
+    padding-inline-start: 0;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translateX(calc(-1 * var(--content-outdent)));
+    width: 8px;
+    height: 100%;
+    background-color: var(--color-brand-100);
+  }
+}

--- a/cdhweb/static_src/styles.scss
+++ b/cdhweb/static_src/styles.scss
@@ -52,6 +52,8 @@
 @import './global/components/accordion.scss';
 @import './global/components/cta.scss';
 @import './global/components/note.scss';
+@import './global/components/pull-quote.scss';
+@import './global/components/block-quote.scss';
 
 // Utility classes. This should go last.
 @import './global/utilities';


### PR DESCRIPTION
Pull quote.

The "note", "block quote" and "pull quote" are all _very_ similar looking. They all have that outdented line, so I've updated the mixin to include the related padding of the containing element.

<img width="891" alt="Screenshot 2024-05-14 at 12 29 40 PM" src="https://github.com/springload/cdh-web/assets/1134713/092798df-87a2-4ac1-93e6-f3df82ed89e2">
<img width="403" alt="Screenshot 2024-05-14 at 12 29 50 PM" src="https://github.com/springload/cdh-web/assets/1134713/e3e83835-02f1-40ac-bc24-0109d5c1071d">
