### PR TITLE
Rich text stylings

### DIFF
--- a/cdhweb/pages/templates/cdhpages/blocks/accordion_block.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/accordion_block.html
@@ -9,7 +9,7 @@
         {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-accordion__chevron-up" %}
         {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-accordion__chevron-down" %}
       </summary>
-      <div class="sk-accordion__content rich-text">
+      <div class="sk-accordion__content">
         {{ item.body|richtext }}
       </div>
     </details>

--- a/cdhweb/pages/templates/cdhpages/blocks/block_quote.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/block_quote.html
@@ -1,3 +1,3 @@
 {% load wagtailcore_tags %}
 
-<div class="block-quote rich-text">{{ self.quote|richtext }}</div>
+<div class="block-quote">{{ self.quote|richtext }}</div>

--- a/cdhweb/pages/templates/cdhpages/blocks/note.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/note.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 
-<div class="note rich-text">
+<div class="note">
     {% if self.heading %}
     <h2>{{ self.heading }}</h2>
     {% endif %}

--- a/cdhweb/pages/templates/cdhpages/blocks/pull_quote.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/pull_quote.html
@@ -2,9 +2,9 @@
 
 <figure class="pull-quote">
     <blockquote>
-        <div class="pull-quote__quote rich-text">{{ self.quote|richtext }}</div>
+        <div class="pull-quote__quote">{{ self.quote|richtext }}</div>
     </blockquote>
     {% if self.attribution %}
-        <figcaption class="pull-quote__citation rich-text">{{ self.attribution|richtext }}</figcaption>
+        <figcaption class="pull-quote__citation">{{ self.attribution|richtext }}</figcaption>
     {% endif %}
 </figure>

--- a/cdhweb/static_src/global/components/accordion.scss
+++ b/cdhweb/static_src/global/components/accordion.scss
@@ -1,5 +1,6 @@
 .sk-accordion {
   :where(details) {
+    margin: 0;
     border-block-start: 1px solid var(--color-grey-100);
 
     &:last-child {

--- a/cdhweb/static_src/global/components/breadcrumbs.scss
+++ b/cdhweb/static_src/global/components/breadcrumbs.scss
@@ -28,6 +28,7 @@
   display: none;
   align-items: center;
   gap: px2rem(9); // space before '/'
+  margin: 0;
 
   @include sm {
     display: flex;

--- a/cdhweb/static_src/global/css-variables/typography.scss
+++ b/cdhweb/static_src/global/css-variables/typography.scss
@@ -2,5 +2,5 @@
   --font-family-primary: 'Brown', Avenir, Montserrat, Corbel, 'URW Gothic',
     source-sans-pro, sans-serif;
 
-  --base-line-height: calc(0.6rem + 1em);
+  --base-line-height: 1.625;
 }

--- a/cdhweb/static_src/global/elements/typography.scss
+++ b/cdhweb/static_src/global/elements/typography.scss
@@ -1,7 +1,3 @@
-// Styles for longform and "rich" text are in rich-text.scss.
-// These are some base rules for all typography, inside a rich-text
-// wrapper or not.
-
 h1 {
   @include h1;
 }
@@ -11,16 +7,10 @@ h2 {
 h3 {
   @include h3;
 }
-h4 {
+h4,
+h5,
+h6 {
   @include h4;
-}
-
-p {
-  // margin bottom by default.
-  // Safety net in case paragraph appears without a rich-text wrapper.
-  // Rich-text styles should override and ensure the last child of a
-  // rich-text wrapper does not have a bottom margin.
-  margin-bottom: 1em;
 }
 
 a {

--- a/cdhweb/static_src/global/mixins/typography.scss
+++ b/cdhweb/static_src/global/mixins/typography.scss
@@ -26,26 +26,23 @@
   }
 }
 
-// TODO styles for h3 and onwards
 @mixin h3 {
-  font-size: px2rem(22);
-  line-height: 1.4;
+  font-size: px2rem(24);
+  line-height: 1.125;
   font-weight: bold;
 
-  @include xl {
-    font-size: px2rem(24);
-    line-height: 1.45;
+  @include sm {
+    font-size: px2rem(28);
   }
 }
 
 @mixin h4 {
-  font-size: px2rem(18);
-  line-height: 1.33;
+  font-size: px2rem(20);
+  line-height: 1.125;
   font-weight: bold;
 
   @include xl {
-    font-size: px2rem(20);
-    line-height: 1.4;
+    font-size: px2rem(24);
   }
 }
 

--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -43,9 +43,6 @@
   h6 {
     margin-bottom: var(--space-l6-sm);
   }
-  p {
-    margin-bottom: var(--space-default);
-  }
 
   *:has(+ h2) {
     margin-bottom: var(--space-l2-lg);

--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -11,7 +11,6 @@
   --space-l5-lg: #{px2rem(40)};
   --space-l6-lg: #{px2rem(40)};
 
-  --space-l1-sm: calc(var(--space-l1-lg) / 4);
   --space-l2-sm: calc(var(--space-l2-lg) / 4);
   --space-l3-sm: calc(var(--space-l3-lg) / 4);
   --space-l4-sm: calc(var(--space-l4-lg) / 4);

--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -1,56 +1,98 @@
-// Styles for body copy, aka "rich text".
-// Wrap body copy elements in a div/section with the class "rich-text".
-// Works best if the direct children are the typographic elements
-// (headings, p etc). This ensures that the .rich-text container doesn't
-// have extra space at the start/end.
-// :where() selector is used to keep specificity low.
-:where(.rich-text) {
-  --space-between-els: 1lh; // relative so it scales to bigger/smaller text
-  --space-between-sections: #{px2rem(40)};
+// By default, every prose element has a bottom margin.
+// `li` is excluded because list item spacing is handled later on.
+// Same with headings because they have their own, more specific spacing values.
+// Ignore header and footer, they have their own styles.
+:where(main) {
+  --space-default: 1rem;
 
-  @include xl {
-    --space-between-sections: #{px2rem(64)};
+  --space-l2-lg: #{px2rem(56)};
+  --space-l3-lg: #{px2rem(40)};
+  --space-l4-lg: #{px2rem(24)};
+  --space-l5-lg: #{px2rem(40)};
+  --space-l6-lg: #{px2rem(40)};
+
+  --space-l1-sm: calc(var(--space-l1-lg) / 4);
+  --space-l2-sm: calc(var(--space-l2-lg) / 4);
+  --space-l3-sm: calc(var(--space-l3-lg) / 4);
+  --space-l4-sm: calc(var(--space-l4-lg) / 4);
+  --space-l5-sm: calc(var(--space-l5-lg) / 4);
+  --space-l6-sm: calc(var(--space-l6-lg) / 4);
+
+  --space-list-items: #{px2rem(8)};
+
+  @include md {
+    --space-l2-lg: #{px2rem(104)};
   }
 
-  > * {
-    margin-bottom: var(--space-between-els, 1em);
+  :is(p, ul, ol) {
+    margin-bottom: var(--space-default);
+  }
+  // Headings have a little more bottom spacing than other prose elements
+  h2 {
+    margin-bottom: var(--space-l2-sm);
+  }
+  h3 {
+    margin-bottom: var(--space-l3-sm);
+  }
+  h4 {
+    margin-bottom: var(--space-l4-sm);
+  }
+  h5 {
+    margin-bottom: var(--space-l5-sm);
+  }
+  h6 {
+    margin-bottom: var(--space-l6-sm);
+  }
+  p {
+    margin-bottom: var(--space-default);
   }
 
-  // When we encounter a heading, that can be considered a new "section" of
-  // the content so should have a nice big space above...
-  // Note: h1s are assumed to be outside of the `rich-text` area, as they're
-  // typically in a hero banner rather than coming from a WYSIWYG with other text.
-  :is(h2, h3, h4, h5, h6) {
-    margin-top: var(--space-between-sections);
+  *:has(+ h2) {
+    margin-bottom: var(--space-l2-lg);
   }
-  // ...unless a heading appears immediately after another heading, in which case we need to reduce the spacing.
-  h2 + h3,
-  h3 + h4,
-  h4 + h5,
-  h5 + h6 {
-    margin-top: var(--space-between-els, 1em);
+  *:has(+ h3) {
+    margin-bottom: var(--space-l3-lg);
   }
-
-  // Remove any orphan vertical space at the start/end of the rich-text block.
-  // NOTE: this assumes items are direct children of .rich-text container.
-  > * {
-    &:first-child {
-      margin-top: 0;
-    }
-    &:last-child {
-      margin-bottom: 0;
-    }
+  *:has(+ h4) {
+    margin-bottom: var(--space-l4-lg);
+  }
+  *:has(+ h5) {
+    margin-bottom: var(--space-l5-lg);
+  }
+  *:has(+ h6) {
+    margin-bottom: var(--space-l6-lg);
   }
 
-  ul,
-  ol {
-    // Undo padding:0 from the css reset, which kills list indentation.
-    padding: revert;
+  // Headings followed immediately by a heading of a level down
+  // should have only a small gap below.
+  :where(h2):has(+ h3) {
+    margin-bottom: var(--space-l2-sm);
+  }
+  :where(h3):has(+ h4) {
+    margin-bottom: var(--space-l3-sm);
+  }
+  :where(h4):has(+ h5) {
+    margin-bottom: var(--space-l4-sm);
+  }
+  :where(h5):has(+ h6) {
+    margin-bottom: var(--space-l5-sm);
   }
 
-  // Collapsing margins should ensure we don't get extra space between this and preceding element.
-  // i.e. no `:not(:first...)` required.
-  li {
-    margin-top: 0.5em;
+  // List item spacing.
+  :where(li):has(+ li) {
+    margin-bottom: var(--space-list-items);
+  }
+
+  // Nested list spacing.
+  // This is the only place we need to use margin-top :'(
+  :where(li) :is(ul, ol) {
+    margin-top: var(--space-list-items);
+  }
+
+  // Remove the bottom margin on the last prose element
+  // (i.e. if it has no next sibling).
+  // TODO: Could there be an argument to apply this to ALL elements (*) with no next sibling?
+  :is(p, ul, ol, h1, h2, h3, h4, h5, h6):not(:has(+ *)) {
+    margin-bottom: 0;
   }
 }

--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -5,17 +5,23 @@
 :where(main) {
   --space-default: 1rem;
 
-  --space-l2-lg: #{px2rem(56)};
-  --space-l3-lg: #{px2rem(40)};
-  --space-l4-lg: #{px2rem(24)};
-  --space-l5-lg: #{px2rem(40)};
-  --space-l6-lg: #{px2rem(40)};
+  // Space for headings.
+  // Note the space is actually applied as a bottom margin to the element *before*
+  // the heading, but are based on the level of that heading.
+  // So in the case of `p + h2`, the p gets a big margin-bottom.
+  --space-h2-lg: #{px2rem(56)};
+  --space-h3-lg: #{px2rem(40)};
+  --space-h4-lg: #{px2rem(24)};
+  // Note, h5 and h6 are styled the same as h4 currently.
+  // TODO, maybe reassess once real content is in.
+  --space-h5-lg: #{px2rem(24)};
+  --space-h6-lg: #{px2rem(24)};
 
-  --space-l2-sm: calc(var(--space-l2-lg) / 4);
-  --space-l3-sm: calc(var(--space-l3-lg) / 4);
-  --space-l4-sm: calc(var(--space-l4-lg) / 4);
-  --space-l5-sm: calc(var(--space-l5-lg) / 4);
-  --space-l6-sm: calc(var(--space-l6-lg) / 4);
+  --space-h2-sm: calc(var(--space-h2-lg) / 4);
+  --space-h3-sm: calc(var(--space-h3-lg) / 4);
+  --space-h4-sm: calc(var(--space-h4-lg) / 4);
+  --space-h5-sm: calc(var(--space-h5-lg) / 4);
+  --space-h6-sm: calc(var(--space-h6-lg) / 4);
 
   --space-list-items: #{px2rem(8)};
 

--- a/cdhweb/static_src/styles.scss
+++ b/cdhweb/static_src/styles.scss
@@ -31,8 +31,7 @@
 @import './global/layout/page-layout.scss';
 @import './global/layout/streamfields.scss';
 
-// Styles for long-form prose, inside a 'rich-text' wrapper.
-// Mainly for handling spacing between each type of typographic element
+// Spacing between each type of typographic element.
 @import './global/rich-text';
 
 // Components

--- a/templates/500.html
+++ b/templates/500.html
@@ -13,10 +13,8 @@
   <body class="{% block body_class %}{% endblock %}">
 
     <div class="grid-full error-page-content">
-      <div class="rich-text">
-        <h1>Error 500</h1>
-        <p>Something went wrong. Please try reloading the page, or <a href="/">return to home</a>.</p>
-      </div>
+      <h1>Error 500</h1>
+      <p>Something went wrong. Please try reloading the page, or <a href="/">return to home</a>.</p>
     </div>
 
     {% if SENTRY_DSN_FED %}

--- a/templates/includes/standard_hero.html
+++ b/templates/includes/standard_hero.html
@@ -3,7 +3,7 @@
 <div class="standard-hero content-width grid-standard">
     
     <h1 class="standard-hero__title">{{ self.title}}</h1>
-    <div class="standard-hero__description rich-text">
+    <div class="standard-hero__description">
         {% if self.description %}
             {{ self.description|richtext }}
         {% endif %}


### PR DESCRIPTION
Rich text styling. Trialling something I've been thinking about for a while, rich-text without the `.rich-text` wrapper 😱 

Styles adapted from [an old pen of mine](https://codepen.io/liamj/pen/vYaYLmW?editors=1100), but with the top spacing of headings made more specific to the CDH designs.



<img width="713" alt="Screenshot 2024-05-20 at 3 20 11 PM" src="https://github.com/springload/cdh-web/assets/1134713/26a6ee6d-36a8-4ad8-8414-fc220db3c3d5">
