### PR TITLE
Add search form to main navs

### DIFF
--- a/cdhweb/static_src/components/MainNavDesktop/MainNavDesktopItem.tsx
+++ b/cdhweb/static_src/components/MainNavDesktop/MainNavDesktopItem.tsx
@@ -2,6 +2,7 @@ import { MouseEvent, useId } from 'react';
 import Svg from '../svg/svg';
 import cx from 'classnames';
 import { MainNavItemPrimary, NavItem } from '../../data-types';
+import SearchForm from '../SearchForm/SearchForm';
 
 type DesktopMenuItemProps = {
   item: MainNavItemPrimary;
@@ -142,7 +143,10 @@ const DesktopMenuItem = ({
                   {!item.isSearch ? (
                     <SubmenuColumns items={item.l2_items} />
                   ) : (
-                    <p>TODO search</p>
+                    <SearchForm
+                      searchUrl={item.link_url}
+                      extraClasses="main-nav-desktop__search-form"
+                    />
                   )}
                 </div>
               </div>

--- a/cdhweb/static_src/components/MainNavMobile/MainNavMobile.mount.tsx
+++ b/cdhweb/static_src/components/MainNavMobile/MainNavMobile.mount.tsx
@@ -31,11 +31,14 @@ const initComponent: InitComponent = (componentEl) => {
   const secondaryNavDataSimplified: MainNavDataSecondarySimplified =
     secondaryNavData.secondary_nav_data.secondary_nav;
 
+  const searchUrl = componentEl.getAttribute('data-search-url');
+
   const root = createRoot(componentEl);
   root.render(
     <MainNavMobile
       primaryNavData={primaryNavDataSimplified}
       secondaryNavData={secondaryNavDataSimplified}
+      searchUrl={searchUrl || '/search'}
     />,
   );
 

--- a/cdhweb/static_src/components/MainNavMobile/MainNavMobile.tsx
+++ b/cdhweb/static_src/components/MainNavMobile/MainNavMobile.tsx
@@ -6,15 +6,18 @@ import {
 } from '../../data-types';
 import Svg from '../svg/svg';
 import cx from 'classnames';
+import SearchForm from '../SearchForm/SearchForm';
 
 type DesktopMenuDataType = {
   primaryNavData: MainNavDataPrimarySimplified;
   secondaryNavData: MainNavDataSecondarySimplified;
+  searchUrl: string;
 };
 
 const MainNavMobile = ({
   primaryNavData,
   secondaryNavData,
+  searchUrl,
 }: DesktopMenuDataType): JSX.Element => {
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   return (
@@ -68,7 +71,8 @@ const MainNavMobile = ({
             )}
 
             <div className="mobile-menu__secondary-content">
-              <div>TODO search</div>
+              <h2>Search</h2>
+              <SearchForm searchUrl={searchUrl} />
 
               {secondaryNavData.items.length > 0 && (
                 <ul className="mobile-menu__secondary-nav-list">

--- a/cdhweb/static_src/components/SearchForm/SearchForm.tsx
+++ b/cdhweb/static_src/components/SearchForm/SearchForm.tsx
@@ -1,0 +1,59 @@
+import { useId } from 'react';
+import cx from 'classnames';
+
+type Props = {
+  searchUrl: string;
+  extraClasses?: string;
+};
+/**
+ * TSX version of search_form.html, for when used in React components like the main nav.
+ */
+const SearchForm = ({ searchUrl, extraClasses }: Props): JSX.Element => {
+  const uniqueId = useId();
+
+  return (
+    <form className={cx('search-form', extraClasses)} action={searchUrl}>
+      <label className="sr-only" htmlFor={`search-input_${uniqueId}`}>
+        Search
+      </label>
+      <div className="search-form__input-btn-group">
+        <input type="text" id={`search-input_${uniqueId}`} name="q" />
+        <input type="submit" value="Search" />
+      </div>
+      <fieldset className="search-form__filters">
+        <legend className="sr-only">Filter search results by</legend>
+        <div className="search-form__radio">
+          <input
+            type="radio"
+            name="filter"
+            id={`${uniqueId}_everything`}
+            checked
+          />
+          <label htmlFor={`${uniqueId}_everything`}>Everything</label>
+        </div>
+        <div className="search-form__radio">
+          <input type="radio" name="filter" id={`${uniqueId}_people`} />
+          <label htmlFor={`${uniqueId}_people`}>People</label>
+        </div>
+        <div className="search-form__radio">
+          <input type="radio" name="filter" id={`${uniqueId}_projects`} />
+          <label htmlFor={`${uniqueId}_projects`}>Projects</label>
+        </div>
+        <div className="search-form__radio">
+          <input type="radio" name="filter" id={`${uniqueId}_events`} />
+          <label htmlFor={`${uniqueId}_events`}>Events</label>
+        </div>
+        <div className="search-form__radio">
+          <input
+            type="radio"
+            name="filter"
+            id={`${uniqueId}_blogs-and-news"`}
+          />
+          <label htmlFor={`${uniqueId}_blogs-and-news"`}>Blogs & news</label>
+        </div>
+      </fieldset>
+    </form>
+  );
+};
+
+export default SearchForm;

--- a/cdhweb/static_src/global/components/main-nav-desktop.scss
+++ b/cdhweb/static_src/global/components/main-nav-desktop.scss
@@ -186,7 +186,7 @@
   @include xl {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 48;
+    gap: 48px;
   }
 }
 
@@ -204,4 +204,8 @@
       margin-block-start: 0;
     }
   }
+}
+
+.main-nav-desktop__search-form {
+  grid-column: 1 / -1;
 }

--- a/cdhweb/static_src/global/components/main-nav-mobile.scss
+++ b/cdhweb/static_src/global/components/main-nav-mobile.scss
@@ -147,6 +147,12 @@
 
 .mobile-menu__secondary-content {
   padding-block: 32px 48px;
+
+  :where(h2) {
+    font-size: px2rem(17);
+    margin-block-end: 20px;
+    font-weight: 900;
+  }
 }
 
 .mobile-menu__secondary-nav-list {
@@ -158,6 +164,7 @@
   flex-direction: column;
   gap: 8px;
   font-size: px2rem(14);
+  margin-block-start: 32px;
 }
 
 .mobile-menu__cta {

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -9,7 +9,7 @@
 {% secondary_navigation as secondary_nav %}
 
 <header class="header">
-    <nav class="main-nav-mobile" data-component="main-nav-mobile" aria-label="Main">
+    <nav class="main-nav-mobile" data-component="main-nav-mobile" aria-label="Main" data-search-url="{% url 'search' %}">
         {# the following gets swapped out when react component mounts #}
         <div class="mobile-menu__header">
             <a href="/" aria-label="The Center for Digital Humanities at Princeton" class="mobile-menu__logo-link">

--- a/templates/includes/search_form.html
+++ b/templates/includes/search_form.html
@@ -1,13 +1,13 @@
 {% load core_tags %}
 
 {% comment %} 
-  This form will appear in more than one place on the page (header, footer, possibly elsewhere).
+  This form will appear in more than one place on the page (header (though that's a tsx version), footer, and possibly elsewhere).
   So `uniqueID` is used to prefix IDs (and their `for`s), so we don't get duplicate IDs in the markup.
 {% endcomment %}
 <form class="search-form {{ extra_classes }}" action="{% url 'search' %}">
   <label class="sr-only" for="search-input_{{ uniqueID }}">Search</label>
   <div class="search-form__input-btn-group">
-    <input type="text" id="search-input_{{ uniqueID }}" />
+    <input type="text" id="search-input_{{ uniqueID }}" name="q" />
     <input type="submit" value="Search" />
   </div>
   <fieldset class="search-form__filters">


### PR DESCRIPTION
Adds a tsx version of the search form, for use in react components like the main nav. Turns out the search endpoint already works, though the page is un-styled currently.

The html version of this is already in use in the footer, and will be probably added to the search page once I get to that.

<img width="1086" alt="Screenshot 2024-05-21 at 9 37 45 AM" src="https://github.com/springload/cdh-web/assets/1134713/2ea1a3d5-8c64-48c1-898e-1f0163cee42e">
<img width="366" alt="Screenshot 2024-05-21 at 9 37 22 AM" src="https://github.com/springload/cdh-web/assets/1134713/0c5079ea-67d8-47a8-8294-61f8975e5a7d">
