### PR TITLE
Redesign note block

### DIFF
--- a/cdhweb/static_src/global/components/note.scss
+++ b/cdhweb/static_src/global/components/note.scss
@@ -1,5 +1,11 @@
 .note {
-  @include outdented-line-block;
+  background-color: var(--color-brand-5);
+  border: 1px solid var(--color-brand-100);
+  padding: 16px;
+
+  @include sm {
+    padding: 32px;
+  }
 
   :where(h2) {
     margin-block-end: 8px;


### PR DESCRIPTION
Joe redesigned this component after realising it looked too similar to the pull quote and block quote components.

**Before**:
<img width="912" alt="Screenshot 2024-05-21 at 8 57 17 AM" src="https://github.com/springload/cdh-web/assets/1134713/c2d924ef-e41f-4859-a33e-b84216beaca3">


**After**:
<img width="837" alt="Screenshot 2024-05-21 at 10 03 31 AM" src="https://github.com/springload/cdh-web/assets/1134713/55819365-2b37-4d6b-beb4-000bac49f824">
