### PR TITLE
Table FED

### DIFF
--- a/cdhweb/pages/templates/cdhpages/blocks/table_block.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/table_block.html
@@ -1,35 +1,31 @@
 {% load wagtailcore_tags %}
 
 {# Note: This is actually a wagtail typed table, not a standard wagtail table #}
-<section class="block theme theme--{{ self.theme }}">
-    <div class="content-width">
 
-        {# tabindex is because scrollable elements must be focusable (a11y). allows keyboard users to scroll. #}
-        <div class="table-scroll-wrapper" tabindex="0">
-            <table class="table">
-                {% if value.caption %}
-                <caption class="sr-only"> {{ value.caption }} </caption>
-                {% endif %}
-                <thead class="table__thead">
-                    <tr>
-                        {% for col in value.table.columns %}
-                        <th class="table__th" scope="col">{{ col.heading }}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody class="table__tbody">
-                    {% for row in value.table.rows %}
-                    <tr>
-                        {% for block in row %}
-                        <td class="table__td rich-text">{% include_block block %}</td>
-                        {% endfor %}
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% if value.notes %}
-                <caption class="sr-only"> {{ value.notes }} </caption>
-                {% endif %}
-    </div>
-</section>
+{# tabindex is because scrollable elements must be focusable (a11y). allows keyboard users to scroll. #}
+<div class="table-scroll-wrapper" tabindex="0">
+    <table class="table">
+        {% if value.caption %}
+            <caption class="table__caption">{{ value.caption }}</caption>
+        {% endif %}
+        <thead class="table__thead">
+            <tr>
+                {% for col in value.table.columns %}
+                <th class="table__th" scope="col">{{ col.heading }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody class="table__tbody">
+            {% for row in value.table.rows %}
+            <tr>
+                {% for block in row %}
+                <td class="table__td">{% include_block block %}</td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>        
+    </table>
+</div>
+{% if value.notes %}
+    <div class="table__notes">{{ value.notes }}</div>
+{% endif %}

--- a/cdhweb/static_src/global/components/table.scss
+++ b/cdhweb/static_src/global/components/table.scss
@@ -1,0 +1,44 @@
+.table-scroll-wrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: separate;
+
+  color: var(--color-grey-110);
+  font-size: px2rem(18);
+  text-align: left;
+}
+
+.table__thead {
+  background-color: var(--color-brand-10);
+}
+
+.table__th,
+.table__td {
+  vertical-align: top;
+  padding: 6px 2px 6px 16px;
+  border-bottom: 1px solid var(--color-brand-100);
+
+  &:nth-child(1) {
+    padding-left: 2px;
+  }
+}
+
+.table__th {
+  font-weight: bold;
+}
+
+.table__caption {
+  text-align: left;
+  font-size: px2rem(17);
+  font-weight: 900;
+  margin-block-end: 16px;
+}
+
+.table__notes {
+  font-size: px2rem(14);
+  margin-block-start: 12px;
+}

--- a/cdhweb/static_src/styles.scss
+++ b/cdhweb/static_src/styles.scss
@@ -58,6 +58,7 @@
 @import './global/components/note.scss';
 @import './global/components/pull-quote.scss';
 @import './global/components/download.scss';
+@import './global/components/table.scss';
 @import './global/components/search-form.scss';
 @import './global/components/pagination.scss';
 @import './global/components/footer.scss';


### PR DESCRIPTION
Table block FED. Uses scrolling wrapper if absolutely necessary, though this wouldn't happen often.

## Mobile
<img width="356" alt="Screenshot 2024-05-23 at 3 39 30 PM" src="https://github.com/springload/cdh-web/assets/1134713/5fc8c8ff-7734-4220-a7c6-91c1902f3045">

## Desktop
<img width="708" alt="Screenshot 2024-05-23 at 3 44 26 PM" src="https://github.com/springload/cdh-web/assets/1134713/9245b425-8475-4d92-ad4c-16ced123fb8e">
