### PR TITLE
accordion heading FED updates

### DIFF
--- a/cdhweb/pages/blocks/accordion_block.py
+++ b/cdhweb/pages/blocks/accordion_block.py
@@ -43,7 +43,8 @@ class AccordionBlock(blocks.StructBlock):
                             "document-link",
                             "h3",
                             "h4",
-                        ]
+                        ],
+                        help_text="Only use H3 if you have not set an overall heading for the accordion block."
                     ),
                 ),
             ]

--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -13,7 +13,7 @@
   }
 
   // Outdented components:
-  :where(.block-heading) {
+  :where(.block-heading, .block-accordion_block > h2) {
     @include lg {
       margin-left: calc(-1 * var(--content-outdent));
     }

--- a/templates/cdhpages/blocks/accordion_block.html
+++ b/templates/cdhpages/blocks/accordion_block.html
@@ -5,12 +5,16 @@
 {% endif %}
 
 {% if self.description %}
-<div>{{ self.description }}</div>
+  {{ self.description }}
 {% endif %}
 
 <div data-component="accordion" class="sk-accordion">
   {% for item in self.accordion_items %}
-    <h2 class="sr-only">{{ item.heading }}</h2>
+    {% if self.heading %}
+      <h3 class="sr-only">{{ item.heading }}</h3>
+    {% else %}
+      <h2 class="sr-only">{{ item.heading }}</h2>
+    {% endif %}
     <details>
       <summary aria-label="Toggle section: {{ item.heading }}">
         {{ item.heading }}


### PR DESCRIPTION
## CMS
<img width="772" alt="Screenshot 2024-05-23 at 4 45 33 PM" src="https://github.com/springload/cdh-web/assets/1134713/395dc17c-4bc4-443e-98f8-2ceeb2491fce">

## SM
<img width="671" alt="Screenshot 2024-05-23 at 4 44 37 PM" src="https://github.com/springload/cdh-web/assets/1134713/eff90080-17b1-4c13-be94-fcc2b4a42643">

## BIG
<img width="990" alt="Screenshot 2024-05-23 at 4 48 14 PM" src="https://github.com/springload/cdh-web/assets/1134713/7611560b-b694-4d42-84c1-ad4e803a1902">
