### PR TITLE
Fix blockquote styling double-up

### DIFF
--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -65,7 +65,7 @@
     margin-bottom: var(--space-h6-lg);
   }
 
-  :where(blockquote) {
+  :where(.block-rich_text blockquote) {
     @include outdented-line-block;
   }
 


### PR DESCRIPTION
When we made the blockquote be part of the rich text editor, it meant that the pull quote was getting a styling double-up – once to the `.pull-quote` wrapper, and again tot he `<blockquote>`. But it needs to be applied to the whole `pull-quote` so that the attribution also gets the decoration.

<img width="443" alt="Screenshot 2024-05-27 at 4 41 27 PM" src="https://github.com/springload/cdh-web/assets/1134713/5dc6f352-deaa-484b-9876-4f1bd2d28b80">

So this change undoes the global "all blockquotes anywhere" styling.

<img width="856" alt="Screenshot 2024-05-28 at 9 30 46 AM" src="https://github.com/springload/cdh-web/assets/1134713/bb141266-4e77-4d51-af98-7a2675cc1f4c">
