### PR TITLE
Hosted video FED

### DIFF
--- a/cdhweb/static_src/global/components/video.scss
+++ b/cdhweb/static_src/global/components/video.scss
@@ -1,7 +1,9 @@
-.sk-video__iframe {
+.sk-video__iframe,
+.block-hosted_video_block iframe {
   aspect-ratio: 16/9;
   width: 100%;
   display: block;
+  height: unset; // undo hosted video inline style
 }
 
 .sk-video__transcript {

--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -31,14 +31,20 @@
         .block-cta_block,
         .block-note,
         .block-pull_quote,
-        .block-video_block
+        .block-video_block,
+        .block-hosted_video_block
       ) {
       max-inline-size: var(--reading-max-width);
     }
   }
 
   // Outdented components:
-  :where(.block-heading, .block-accordion_block > h2, .block-video_block > h2) {
+  :where(
+      .block-heading,
+      .block-accordion_block > h2,
+      .block-video_block > h2,
+      .block-hosted_video_block > h2
+    ) {
     @include lg {
       margin-left: calc(-1 * var(--content-outdent));
     }

--- a/templates/cdhpages/blocks/hosted_video_block.html
+++ b/templates/cdhpages/blocks/hosted_video_block.html
@@ -1,24 +1,32 @@
 {% load wagtailcore_tags %}
 
+{% comment %}
+    This template is basically the same as video_block.html, except for the iframe bit – see below.
+{% endcomment %}
+
 {% if self.heading %}
-{% include_block self.heading %}
+    {% include_block self.heading %}
 {% endif %}
 
+{% comment %}
+    Iframe rendering happens inside this black box. 
+    We don't control the HTML, so can't add the accessibility title="{{ accessibility_description }}"
+    We also can't do anything about the non-unique `id` added to the iframe (pre-Springload legacy issue).
+    We use CSS to override the inline styles like `height`.
+{% endcomment %}
 {{ self.video_url }}
-{{ self.accessibility_description }}
 
 {% if self.transcript %}
-<div class="sk-video-transcript">
-    <details class="sk-video-transcript__details">
-        <summary class="sk-video-transcript__summary">
-            {% include 'springkit/includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-video-transcript__icon" %}
-            <span class="sk-video-transcript__summary-text">
-                Video transcript
+    <details class="sk-video__transcript">
+        <summary class="sk-video__transcript-summary">
+            <span>
+                Show video transcript
             </span>
+            {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-up" %}
+            {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-down" %}
         </summary>
-        <div class="sk-video-transcript__content">
+        <div class="sk-video__transcript-content">
             {{ self.transcript }}
         </div>
     </details>
-</div>
 {% endif %}


### PR DESCRIPTION
Component for Princeton's own hosted video platform. Shares styles with the main video block (youtube, vimeo)

<img width="1055" alt="Screenshot 2024-05-28 at 1 44 20 PM" src="https://github.com/springload/cdh-web/assets/1134713/9f8f206b-6dfe-46af-9d9c-92de4e01b807">
