### PR TITLE
Fix hosted video style

### DIFF
--- a/cdhweb/static_src/global/components/video.scss
+++ b/cdhweb/static_src/global/components/video.scss
@@ -1,5 +1,5 @@
 .sk-video__iframe,
-.block-hosted_video_block iframe {
+.block-embed iframe {
   aspect-ratio: 16/9;
   width: 100%;
   display: block;

--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -36,7 +36,7 @@
         .block-note,
         .block-pull_quote,
         .block-video_block,
-        .block-hosted_video_block
+        .block-embed
       ) {
       max-inline-size: var(--reading-max-width);
     }
@@ -47,7 +47,7 @@
       .block-heading,
       .block-accordion_block > h2,
       .block-video_block > h2,
-      .block-hosted_video_block > h2
+      .block-embed > h2
     ) {
     @include lg {
       margin-left: calc(-1 * var(--content-outdent));


### PR DESCRIPTION
Following some BED work, the generated classname changed. 

I guess this is another good reason to not render those generated divs, as this isn't the first time a change has broken the styles. I will persevere with them a little longer...