### PR TITLE
Streamfield wrapper overhaul and featured tiles style

### DIFF
--- a/cdhweb/pages/templates/cdhpages/blocks/feature_block.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/feature_block.html
@@ -1,25 +1,28 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 {% image self.image width-400 as img_base %}
-<div class="feature">
-    <div class="feature__text-content">
-      <h2>{{ self.heading }}</h2>
-      {{ self.feature_text|richtext }}
-      {% if self.cta_buttons %}
-        {% include_block self.cta_buttons %}
-      {% endif %}
-    </div>
 
-    {% image self.image width-750 as img_base %}
-    {% image self.image width-1200 as img_sm %}
-    {% image self.image width-1400 as img_md %}
+<div class="block block--feature">
+  <div class="feature">
+      <div class="feature__text-content">
+        <h2>{{ self.heading }}</h2>
+        {{ self.feature_text|richtext }}
+        {% if self.cta_buttons %}
+          {% include_block self.cta_buttons %}
+        {% endif %}
+      </div>
 
-    <picture class="feature__img">
-      <source srcset="{{ img_sm.url }}" media="(min-width: 500px)">
-      <source srcset="{{ img_md.url }}" media="(min-width: 768px)">
-      <img 
-        src="{{ img_base.url }}" 
-        alt="{{ self.alt_text|default:img_base.alt }}"
-        loading="lazy"
-    />
-  </picture>
+      {% image self.image width-750 as img_base %}
+      {% image self.image width-1200 as img_sm %}
+      {% image self.image width-1400 as img_md %}
+
+      <picture class="feature__img">
+        <source srcset="{{ img_sm.url }}" media="(min-width: 500px)">
+        <source srcset="{{ img_md.url }}" media="(min-width: 768px)">
+        <img 
+          src="{{ img_base.url }}" 
+          alt="{{ self.alt_text|default:img_base.alt }}"
+          loading="lazy"
+      />
+    </picture>
+  </div>
 </div>

--- a/cdhweb/pages/templates/cdhpages/blocks/image_block.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/image_block.html
@@ -17,47 +17,48 @@
     {% image self.image width-2300 as img_xxxl %}
 {% endif %}
 
-<figure class="sk-image sk-image--{{ self.size }}">    
-    <picture>
-        {% if img_sm %}
-            <source srcset="{{ img_sm.url }}" media="(min-width: 500px)">
-        {% endif %}
-        {% if img_md %}
-            <source srcset="{{ img_md.url }}" media="(min-width: 768px)">
-        {% endif %}
-        {% if img_lg %}
-            <source srcset="{{ img_lg.url }}" media="(min-width: 1024px)">
-        {% endif %}
-        {% if img_xl %}
-            <source srcset="{{ img_xl.url }}" media="(min-width: 1200px)">
-        {% endif %}
-        {% if img_xxl %}
-            <source srcset="{{ img_xxl.url }}" media="(min-width: 1440px)">
-        {% endif %}
-        {% if img_xxxl %}
-            <source srcset="{{ img_xxxl.url }}" media="(min-width: 1920px)">
-        {% endif %}
-        <img class="sk-image__img"
-            src="{{ img_base.url }}" 
-            alt="{{ self.alt_text|default:img_base.alt }}"
-            loading="lazy"
-            style="aspect-ratio: {{ img_base.width|unlocalize }} / {{ img_base.height|unlocalize }}"
-        />
-    </picture>
-
-    {% if self.credit or self.caption %}
-        <figcaption class="sk-image__text-content">
-            {% if self.credit %}
-                <div class="sk-image__credit">
-                    {{ self.credit|richtext }}
-                </div>
+<div class="block block--image">
+    <figure class="sk-image sk-image--{{ self.size }}">    
+        <picture>
+            {% if img_sm %}
+                <source srcset="{{ img_sm.url }}" media="(min-width: 500px)">
             {% endif %}
-            {% if self.caption %}
-                <div class="sk-image__caption">
-                    {{ self.caption|richtext }}
-                </div>
+            {% if img_md %}
+                <source srcset="{{ img_md.url }}" media="(min-width: 768px)">
             {% endif %}
-        </figcaption>
-    {% endif %}
-</figure>
+            {% if img_lg %}
+                <source srcset="{{ img_lg.url }}" media="(min-width: 1024px)">
+            {% endif %}
+            {% if img_xl %}
+                <source srcset="{{ img_xl.url }}" media="(min-width: 1200px)">
+            {% endif %}
+            {% if img_xxl %}
+                <source srcset="{{ img_xxl.url }}" media="(min-width: 1440px)">
+            {% endif %}
+            {% if img_xxxl %}
+                <source srcset="{{ img_xxxl.url }}" media="(min-width: 1920px)">
+            {% endif %}
+            <img class="sk-image__img"
+                src="{{ img_base.url }}" 
+                alt="{{ self.alt_text|default:img_base.alt }}"
+                loading="lazy"
+                style="aspect-ratio: {{ img_base.width|unlocalize }} / {{ img_base.height|unlocalize }}"
+            />
+        </picture>
 
+        {% if self.credit or self.caption %}
+            <figcaption class="sk-image__text-content">
+                {% if self.credit %}
+                    <div class="sk-image__credit">
+                        {{ self.credit|richtext }}
+                    </div>
+                {% endif %}
+                {% if self.caption %}
+                    <div class="sk-image__caption">
+                        {{ self.caption|richtext }}
+                    </div>
+                {% endif %}
+            </figcaption>
+        {% endif %}
+    </figure>
+</div>

--- a/cdhweb/pages/templates/cdhpages/blocks/rich_text.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/rich_text.html
@@ -1,2 +1,4 @@
 {% load wagtailcore_tags %}
-{{ self | richtext }}
+<div class="block block--paragraph">
+  {{ self | richtext }}
+</div>

--- a/cdhweb/pages/templates/cdhpages/blocks/table_block.html
+++ b/cdhweb/pages/templates/cdhpages/blocks/table_block.html
@@ -2,30 +2,32 @@
 
 {# Note: This is actually a wagtail typed table, not a standard wagtail table #}
 
-{# tabindex is because scrollable elements must be focusable (a11y). allows keyboard users to scroll. #}
-<div class="table-scroll-wrapper" tabindex="0">
-    <table class="table">
-        {% if value.caption %}
-            <caption class="table__caption">{{ value.caption }}</caption>
-        {% endif %}
-        <thead class="table__thead">
-            <tr>
-                {% for col in value.table.columns %}
-                <th class="table__th" scope="col">{{ col.heading }}</th>
+<div class="block block--table">
+    {# tabindex is because scrollable elements must be focusable (a11y). allows keyboard users to scroll. #}
+    <div class="table-scroll-wrapper" tabindex="0">
+        <table class="table">
+            {% if value.caption %}
+                <caption class="table__caption">{{ value.caption }}</caption>
+            {% endif %}
+            <thead class="table__thead">
+                <tr>
+                    {% for col in value.table.columns %}
+                    <th class="table__th" scope="col">{{ col.heading }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody class="table__tbody">
+                {% for row in value.table.rows %}
+                <tr>
+                    {% for block in row %}
+                    <td class="table__td">{% include_block block %}</td>
+                    {% endfor %}
+                </tr>
                 {% endfor %}
-            </tr>
-        </thead>
-        <tbody class="table__tbody">
-            {% for row in value.table.rows %}
-            <tr>
-                {% for block in row %}
-                <td class="table__td">{% include_block block %}</td>
-                {% endfor %}
-            </tr>
-            {% endfor %}
-        </tbody>        
-    </table>
+            </tbody>        
+        </table>
+    </div>
+    {% if value.notes %}
+        <div class="table__notes">{{ value.notes }}</div>
+    {% endif %}
 </div>
-{% if value.notes %}
-    <div class="table__notes">{{ value.notes }}</div>
-{% endif %}

--- a/cdhweb/static_src/global/components/cta.scss
+++ b/cdhweb/static_src/global/components/cta.scss
@@ -1,4 +1,4 @@
-.block-cta_block {
+.cta {
   border: 1px solid var(--color-brand-100);
   background-color: var(--color-brand-5);
   padding: 24px;

--- a/cdhweb/static_src/global/components/newsletter.scss
+++ b/cdhweb/static_src/global/components/newsletter.scss
@@ -1,11 +1,11 @@
 /*
 Newsletter streamfield block.
 Note: this uses the same `includes/newsletter_form.html` rendered by in <footer>.
-We don't have a streamfield-specific template for it, therefore we're styling this one 
-the streamfield version based on its wagtail-generated class name `.block-newsletter`.
+We don't have a streamfield-specific template for it, but we conditionally add a 
+`.block--newsletter` wrapper when it's used in a streamfield context.
 */
 
-.block-newsletter {
+.block--newsletter {
   --form-control-border-color: var(--color-grey-80);
   --btn-color: var(--color-black);
   --btn-bg: var(--color-brand-100);

--- a/cdhweb/static_src/global/components/tiles.scss
+++ b/cdhweb/static_src/global/components/tiles.scss
@@ -1,3 +1,12 @@
+.tiles--featured {
+  @include full-bleed-bg(var(--color-grey-5));
+  padding-block: 40px;
+
+  @include md {
+    padding-block: 72px;
+  }
+}
+
 // Wrapper for component title and 'see more' link, both of
 // which are optional. Only renders if content is present.
 .tiles__title-wrapper {
@@ -34,7 +43,7 @@
   row-gap: 40px;
 
   @include sm {
-    grid-template-columns: repeat(auto-fit, minmax(px2rem(280), 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(px2rem(280), 1fr));
     column-gap: 32px;
   }
 }
@@ -48,6 +57,7 @@
 .tile__text {
   grid-row: 2;
   grid-column: 1;
+  background-color: var(--color-white);
   border: 8px solid var(--color-brand-100);
   border-top: none;
   padding: 24px 12px;

--- a/cdhweb/static_src/global/components/video.scss
+++ b/cdhweb/static_src/global/components/video.scss
@@ -1,5 +1,6 @@
-.sk-video__iframe,
-.block-embed iframe {
+// Apply to both the video block (.sk-video__iframe) and the
+// hosted video block (which we can't access the DOM for)
+.block--video :where(iframe) {
   aspect-ratio: 16/9;
   width: 100%;
   display: block;

--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -14,21 +14,20 @@
     // Cases where there should be a `sm` space above:
     &:where(
         :is(
-            .block-image,
-            .block-table,
-            .block-note,
-            .block-paragraph,
-            .block-pull_quote,
-            .block-accordion_block:not(:has(> h2)),
-            .block-embed:not(:has(> h2)),
-            .block-video_block:not(:has(> h2))
+            .block--image,
+            .block--table,
+            .block--note,
+            .block--paragraph,
+            .block--pull-quote,
+            .block--accordion:not(:has(> h2)),
+            .block--video:not(:has(> h2))
           )
       ) {
       margin-block-start: var(--streamfield-space-sm);
     }
 
     // Cases where there should be a `xs` space above:
-    &:where(:is(.block-heading + *)) {
+    &:where(:is(.block--heading + *)) {
       margin-block-start: var(--streamfield-space-xs);
     }
   }
@@ -36,15 +35,14 @@
   & > * {
     // Cap width of some (most?) streamfield block types
     &:where(
-        .block-accordion_block,
-        .block-table,
-        .block-paragraph,
-        .block-download_block,
-        .block-cta_block,
-        .block-note,
-        .block-pull_quote,
-        .block-video_block,
-        .block-embed
+        .block--accordion,
+        .block--table,
+        .block--paragraph,
+        .block--download,
+        .block--cta,
+        .block--note,
+        .block--pull-quote,
+        .block--video
       ) {
       max-inline-size: var(--reading-max-width);
     }
@@ -53,12 +51,7 @@
   // Outdented components.
   // Tile block title is excluded because it needs to be wrapped in another
   // container to allow the "see all" link to display in line with it.
-  :where(
-      .block-heading,
-      .block-accordion_block > h2,
-      .block-video_block > h2,
-      .block-embed > h2
-    ) {
+  :where(.block--heading, .block--accordion > h2, .block--video > h2) {
     @include md {
       margin-left: calc(-1 * var(--content-outdent));
     }

--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
 
-  & > * + * {
+  & > :where(.block + .block) {
     // Default `lg` space above each streamfield
     margin-block-start: var(--streamfield-space-lg);
 

--- a/cdhweb/static_src/global/migrated-content.scss
+++ b/cdhweb/static_src/global/migrated-content.scss
@@ -2,7 +2,7 @@
     Regarding content migrated as part of Springload's 2024 rebuild.
     Existing content was dumped into a "migrated" content streamfield block.
 */
-.migrated-content {
+.block--migrated-content {
   :where(h2) {
     @include md {
       margin-left: calc(-1 * var(--content-outdent));

--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -59,7 +59,7 @@
     margin-bottom: var(--space-h6-lg);
   }
 
-  :where(.block-paragraph blockquote) {
+  :where(.block--paragraph blockquote) {
     @include outdented-line-block;
   }
 

--- a/templates/blog/blog_post.html
+++ b/templates/blog/blog_post.html
@@ -8,9 +8,9 @@
     <div class="content-width grid-standard page-layout page-layout--without-sidenav">
         <div class="page-layout__main-content">
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
     </div>

--- a/templates/cdhpages/blocks/accordion_block.html
+++ b/templates/cdhpages/blocks/accordion_block.html
@@ -1,29 +1,32 @@
 {% load wagtailcore_tags %}
 
-{% if self.heading %}
-  {% include_block self.heading %}
-{% endif %}
+<div class="block block--accordion">
 
-{% if self.description %}
-  {{ self.description }}
-{% endif %}
+  {% if self.heading %}
+    {% include_block self.heading %}
+  {% endif %}
 
-<div data-component="accordion" class="sk-accordion">
-  {% for item in self.accordion_items %}
-    {% if self.heading.heading %}
-      <h3 class="sr-only">{{ item.heading }}</h3>
-    {% else %}
-      <h2 class="sr-only">{{ item.heading }}</h2>
-    {% endif %}
-    <details>
-      <summary aria-label="Toggle section: {{ item.heading }}">
-        {{ item.heading }}
-        {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-accordion__chevron-up" %}
-        {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-accordion__chevron-down" %}
-      </summary>
-      <div class="sk-accordion__content">
-        {{ item.body|richtext }}
-      </div>
-    </details>
-  {% endfor %}
+  {% if self.description %}
+    {{ self.description }}
+  {% endif %}
+
+  <div data-component="accordion" class="sk-accordion">
+    {% for item in self.accordion_items %}
+      {% if self.heading.heading %}
+        <h3 class="sr-only">{{ item.heading }}</h3>
+      {% else %}
+        <h2 class="sr-only">{{ item.heading }}</h2>
+      {% endif %}
+      <details>
+        <summary aria-label="Toggle section: {{ item.heading }}">
+          {{ item.heading }}
+          {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-accordion__chevron-up" %}
+          {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-accordion__chevron-down" %}
+        </summary>
+        <div class="sk-accordion__content">
+          {{ item.body|richtext }}
+        </div>
+      </details>
+    {% endfor %}
+  </div>
 </div>

--- a/templates/cdhpages/blocks/article_tile_block.html
+++ b/templates/cdhpages/blocks/article_tile_block.html
@@ -1,27 +1,31 @@
 {% load wagtailcore_tags %}
 
-{% if self.heading or self.see_more_link.page %}
-  <div class="tiles__title-wrapper">
-    {% if self.heading %}
-        {% include_block self.heading %}
+<div class="block block--tiles">
+  <div class="tiles">
+    {% if self.heading or self.see_more_link.page %}
+      <div class="tiles__title-wrapper">
+        {% if self.heading %}
+            {% include_block self.heading %}
+        {% endif %}
+
+        {% if self.see_more_link %}
+          <a href="{{ self.landing_page.url }}">
+              {{ self.see_more_link }}
+          </a>
+        {% endif %}
+      </div>
     {% endif %}
 
-    {% if self.see_more_link %}
-      <a href="{{ self.landing_page.url }}">
-          {{ self.see_more_link }}
-      </a>
+    {% if self.description %}
+      <div class="tiles__intro">
+        {{ self.description }}
+      </div>
     {% endif %}
-  </div>
-{% endif %}
 
-{% if self.description %}
-  <div class="tiles__intro">
-    {{ self.description }}
+    <div class="tiles__list">
+        {% for tile in tiles %} 
+          {% include 'cdhpages/blocks/tile.html' with internal_page=tile tile_type='internal_page_tile' has_component_title=self.heading.heading %}
+        {% endfor %}
+    </div>
   </div>
-{% endif %}
-
-<div class="tiles__list">
-    {% for tile in tiles %} 
-      {% include 'cdhpages/blocks/tile.html' with internal_page=tile tile_type='internal_page_tile' has_component_title=self.heading.heading %}
-    {% endfor %}
 </div>

--- a/templates/cdhpages/blocks/download_block.html
+++ b/templates/cdhpages/blocks/download_block.html
@@ -1,27 +1,29 @@
 {% load wagtailimages_tags wagtailcore_tags %}
 
-<div class="download">
-  {% if self.heading %}
-    <h2>{{ self.heading }}</h2>
-  {% endif %}
-  
-  {% if self.description %}
-    <p>{{ self.description }}</p>
-  {% endif %}
+<div class="block block--download">
+  <div class="download">
+    {% if self.heading %}
+      <h2>{{ self.heading }}</h2>
+    {% endif %}
+    
+    {% if self.description %}
+      <p>{{ self.description }}</p>
+    {% endif %}
 
-  <ul>
-    {% for file in file_links %}
-      <li>
-        <a href="{{ file.file.url }}" download>
-          {% include 'includes/svg.html' with sprite="two-tone" svg="arrow-down" %}
-          <span>
-            <strong class="download__file-title">
-              {{ file.title }}
-            </strong>
-            ({{ file.file_type }}, {{ file.file_size | filesizeformat }})
-          </span>
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
+    <ul>
+      {% for file in file_links %}
+        <li>
+          <a href="{{ file.file.url }}" download>
+            {% include 'includes/svg.html' with sprite="two-tone" svg="arrow-down" %}
+            <span>
+              <strong class="download__file-title">
+                {{ file.title }}
+              </strong>
+              ({{ file.file_type }}, {{ file.file_size | filesizeformat }})
+            </span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
 </div>

--- a/templates/cdhpages/blocks/hosted_video_block.html
+++ b/templates/cdhpages/blocks/hosted_video_block.html
@@ -4,29 +4,31 @@
     This template is basically the same as video_block.html, except for the iframe bit – see below.
 {% endcomment %}
 
-{% if self.heading %}
-    {% include_block self.heading %}
-{% endif %}
+<div class="block block--video">
+    {% if self.heading %}
+        {% include_block self.heading %}
+    {% endif %}
 
-{% comment %}
-    Iframe rendering happens inside this black box. 
-    We don't control the HTML, so can't add the accessibility title="{{ accessibility_description }}"
-    We also can't do anything about the non-unique `id` added to the iframe (pre-Springload legacy issue).
-    We use CSS to override the inline styles like `height`.
-{% endcomment %}
-{{ self.video_url }}
+    {% comment %}
+        Iframe rendering happens inside this black box. 
+        We don't control the HTML, so can't add the accessibility title="{{ accessibility_description }}"
+        We also can't do anything about the non-unique `id` added to the iframe (pre-Springload legacy issue).
+        We use CSS to override the inline styles like `height`.
+    {% endcomment %}
+    {{ self.video_url }}
 
-{% if self.transcript %}
-    <details class="sk-video__transcript">
-        <summary class="sk-video__transcript-summary">
-            <span>
-                Show video transcript
-            </span>
-            {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-up" %}
-            {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-down" %}
-        </summary>
-        <div class="sk-video__transcript-content">
-            {{ self.transcript }}
-        </div>
-    </details>
-{% endif %}
+    {% if self.transcript %}
+        <details class="sk-video__transcript">
+            <summary class="sk-video__transcript-summary">
+                <span>
+                    Show video transcript
+                </span>
+                {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-up" %}
+                {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-down" %}
+            </summary>
+            <div class="sk-video__transcript-content">
+                {{ self.transcript }}
+            </div>
+        </details>
+    {% endif %}
+</div>

--- a/templates/cdhpages/blocks/note.html
+++ b/templates/cdhpages/blocks/note.html
@@ -1,8 +1,10 @@
 {% load wagtailcore_tags %}
 
-<div class="note">
-    {% if self.heading %}
-    <h2>{{ self.heading }}</h2>
-    {% endif %}
-    {{ self.message|richtext }}
+<div class="block block--note">
+    <div class="note">
+        {% if self.heading %}
+        <h2>{{ self.heading }}</h2>
+        {% endif %}
+        {{ self.message|richtext }}
+    </div>
 </div>

--- a/templates/cdhpages/blocks/pull_quote.html
+++ b/templates/cdhpages/blocks/pull_quote.html
@@ -1,10 +1,12 @@
 {% load wagtailcore_tags %}
 
-<figure class="pull-quote">
-    <blockquote>
-        <div class="pull-quote__quote">{{ self.quote|richtext }}</div>
-    </blockquote>
-    {% if self.attribution %}
-        <figcaption class="pull-quote__citation">{{ self.attribution|richtext }}</figcaption>
-    {% endif %}
-</figure>
+<div class="block block--pull-quote">
+    <figure class="pull-quote">
+        <blockquote>
+            <div class="pull-quote__quote">{{ self.quote|richtext }}</div>
+        </blockquote>
+        {% if self.attribution %}
+            <figcaption class="pull-quote__citation">{{ self.attribution|richtext }}</figcaption>
+        {% endif %}
+    </figure>
+</div>

--- a/templates/cdhpages/blocks/standard_tile_block.html
+++ b/templates/cdhpages/blocks/standard_tile_block.html
@@ -1,31 +1,31 @@
 {% load wagtailcore_tags %}
 
-{% if self.featured %}
-    {# make it look different }
-{% endif %}
+<div class="block block--tiles">
+  <div class="tiles {% if self.featured %}tiles--featured{% endif %}">
+    {% if self.heading or self.see_more_link.page %}
+      <div class="tiles__title-wrapper">
+        {% if self.heading %}
+            {% include_block self.heading %}
+        {% endif %}
 
-{% if self.heading or self.see_more_link.page %}
-  <div class="tiles__title-wrapper">
-    {% if self.heading %}
-        {% include_block self.heading %}
+        {% if self.see_more_link.page %}
+          <a href="{{ self.see_more_link.url }}">
+              {{ self.see_more_link.title }}
+          </a>
+        {% endif %}
+      </div>
     {% endif %}
 
-    {% if self.see_more_link.page %}
-      <a href="{{ self.see_more_link.url }}">
-          {{ self.see_more_link.title }}
-      </a>
+    {% if self.description %}
+      <div class="tiles__intro">
+        {{ self.description }}
+      </div>
     {% endif %}
-  </div>
-{% endif %}
 
-{% if self.description %}
-  <div class="tiles__intro">
-    {{ self.description }}
+    <div class="tiles__list">
+        {% for tile in tiles %}  
+          {% include 'cdhpages/blocks/tile.html' with internal_page=tile.value.page tile_type=tile.block.name has_component_title=self.heading.heading %}
+        {% endfor %}
+    </div>
   </div>
-{% endif %}
-
-<div class="tiles__list">
-    {% for tile in tiles %}  
-      {% include 'cdhpages/blocks/tile.html' with internal_page=tile.value.page tile_type=tile.block.name has_component_title=self.heading.heading %}
-    {% endfor %}
 </div>

--- a/templates/cdhpages/blocks/video_block.html
+++ b/templates/cdhpages/blocks/video_block.html
@@ -1,29 +1,31 @@
 {% load wagtailcore_tags %}
 
-{% if self.heading %}
-    {% include_block self.heading %}
-{% endif %}
-
-{% if video_embed_url %}
-    <iframe
-        class="sk-video__iframe"
-        loading="lazy"
-        src="{{ video_embed_url }}"
-        frameborder="0"
-        title="{{ self.accessibility_description }}"
-    ></iframe>
-    {% if self.transcript %}
-        <details class="sk-video__transcript">
-            <summary class="sk-video__transcript-summary">
-                <span>
-                    Show video transcript
-                </span>
-                {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-up" %}
-                {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-down" %}
-            </summary>
-            <div class="sk-video__transcript-content">
-                {{ self.transcript }}
-            </div>
-        </details>
+<div class="block block--video">
+    {% if self.heading %}
+        {% include_block self.heading %}
     {% endif %}
-{% endif %}
+
+    {% if video_embed_url %}
+        <iframe
+            class="sk-video__iframe"
+            loading="lazy"
+            src="{{ video_embed_url }}"
+            frameborder="0"
+            title="{{ self.accessibility_description }}"
+        ></iframe>
+        {% if self.transcript %}
+            <details class="sk-video__transcript">
+                <summary class="sk-video__transcript-summary">
+                    <span>
+                        Show video transcript
+                    </span>
+                    {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-up" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-up" %}
+                    {% include 'includes/svg.html' with sprite="two-tone" svg="chevron-down" classes="sk-video__transcript-icon sk-video__transcript-icon--chevron-down" %}
+                </summary>
+                <div class="sk-video__transcript-content">
+                    {{ self.transcript }}
+                </div>
+            </details>
+        {% endif %}
+    {% endif %}
+</div>

--- a/templates/cdhpages/content_page.html
+++ b/templates/cdhpages/content_page.html
@@ -20,9 +20,9 @@
             {% endif %}
             
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
 

--- a/templates/cdhpages/home_page.html
+++ b/templates/cdhpages/home_page.html
@@ -11,9 +11,9 @@
     <div class="content-width grid-standard page-layout page-layout--without-sidenav">
         <div class="page-layout__main-content">
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
     </div>

--- a/templates/cdhpages/landing_page.html
+++ b/templates/cdhpages/landing_page.html
@@ -16,9 +16,9 @@
     ">
         <div class="page-layout__main-content">
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
 

--- a/templates/events/event_page.html
+++ b/templates/events/event_page.html
@@ -8,9 +8,9 @@
     <div class="content-width grid-standard page-layout page-layout--without-sidenav">
         <div class="page-layout__main-content">
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
     </div>

--- a/templates/includes/newsletter_form.html
+++ b/templates/includes/newsletter_form.html
@@ -4,19 +4,27 @@
 
 {% unique_id as generated_id %}
 
-<h2>
-    Subscribe to our newsletter
-    {% include 'includes/svg.html' with sprite="two-tone" svg="email" %}
-</h2>
-<form action="https://princeton.us16.list-manage.com/subscribe/post?u=a77a39541c9fc9c8b625cb379&amp;id=3f268a40cb" 
-    method="post"
-    name="mc-embedded-subscribe-form"
-    class="text-input-and-button-group {{ extra_classes }}"
-    target="_blank"
->
-    <label for="{{ generated_id }}" class="sr-only">Subscribe to our newsletter</label>
-    <input type="email" value="" name="EMAIL" id="{{ generated_id }}" placeholder="Your email address" required />
-    {# real people should not fill this in and expect good things - do not remove this or risk form bot signups #}
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_a77a39541c9fc9c8b625cb379_3f268a40cb" tabindex="-1" value=""></div>
-    <input type="submit" value="Submit" name="subscribe"/>
-</form>
+{% if not is_not_streamfield %}
+<div class="block block--newsletter">
+{% endif %}
+
+    <h2>
+        Subscribe to our newsletter
+        {% include 'includes/svg.html' with sprite="two-tone" svg="email" %}
+    </h2>
+    <form action="https://princeton.us16.list-manage.com/subscribe/post?u=a77a39541c9fc9c8b625cb379&amp;id=3f268a40cb" 
+        method="post"
+        name="mc-embedded-subscribe-form"
+        class="text-input-and-button-group {{ extra_classes }}"
+        target="_blank"
+    >
+        <label for="{{ generated_id }}" class="sr-only">Subscribe to our newsletter</label>
+        <input type="email" value="" name="EMAIL" id="{{ generated_id }}" placeholder="Your email address" required />
+        {# real people should not fill this in and expect good things - do not remove this or risk form bot signups #}
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_a77a39541c9fc9c8b625cb379_3f268a40cb" tabindex="-1" value=""></div>
+        <input type="submit" value="Submit" name="subscribe"/>
+    </form>
+
+{% if not is_not_streamfield %}
+</div>
+{% endif %}

--- a/templates/people/people_landing_page.html
+++ b/templates/people/people_landing_page.html
@@ -19,9 +19,9 @@
             {# fixed tile block to go here #}
 
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
 

--- a/templates/people/person_page.html
+++ b/templates/people/person_page.html
@@ -9,9 +9,9 @@
 <div class="content-width grid-standard page-layout page-layout--without-sidenav">
     <div class="page-layout__main-content">
         <div class="streamfields-wrapper">
-            {% if page.body %}
-                {% include_block page.body %}
-            {% endif %}
+            {% for block in page.body %}
+                {% include_block block %}
+            {% endfor %}
 
             {% if recent_projects %}
                 <div class="block-tile_block">

--- a/templates/projects/project_page.html
+++ b/templates/projects/project_page.html
@@ -8,9 +8,9 @@
     <div class="content-width grid-standard project-page">
         <div class="project-page__main-content">
             <div class="streamfields-wrapper">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% endif %}
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
             </div>
         </div>
         <div class="project-page__side-content">

--- a/templates/snippets/footer_menu.html
+++ b/templates/snippets/footer_menu.html
@@ -50,7 +50,7 @@
           <div class="footer__address">{{ physical_address|richtext }}</div>
         {% endif %}
         <div class="footer__newsletter">
-          {% include 'includes/newsletter_form.html' %}
+          {% include 'includes/newsletter_form.html' with is_not_streamfield=True %}
         </div>
       </div>
 

--- a/templates/springkit/blocks/cta/cta.html
+++ b/templates/springkit/blocks/cta/cta.html
@@ -1,7 +1,11 @@
 {% load wagtailcore_tags %}
 
-{% if self.introduction %}
-  <p>{{ self.introduction }}</p>
-{% endif %}
+<div class="block block--cta">
+  <div class="cta">
+    {% if self.introduction %}
+      <p>{{ self.introduction }}</p>
+    {% endif %}
 
-{% include_block self.cta_buttons %}
+    {% include_block self.cta_buttons %}
+  </div>
+</div>

--- a/templates/springkit/blocks/heading/jumplinkable_heading.html
+++ b/templates/springkit/blocks/heading/jumplinkable_heading.html
@@ -1,2 +1,4 @@
 {% load wagtailcore_tags %}
-{% include_block self.heading %}
+<div class="block block--heading">
+  {% include_block self.heading %}
+</div>  

--- a/templates/text-content.html
+++ b/templates/text-content.html
@@ -3,6 +3,6 @@
 {# Wrapper for migrated content. #}
 {# This `div` is required to avoid big streamfield-spacing between typographic elements. #}
 {# It also allows us to add some new styling to some of the olf content (e.g. outdented h2) #}
-<div class="migrated-content">
+<div class="block block--migrated-content">
     {{ value|richtext }}
 </div>


### PR DESCRIPTION
Hide whitespace changes when reviewing this.

This PR does two _sort of_ related things. 

**Firstly:** adds a style (background-color & padding) and when a standard tiles block is "featured":
<img width="1328" alt="Screenshot 2024-06-14 at 12 20 27 PM" src="https://github.com/springload/cdh-web/assets/1134713/98578fef-8ae0-42b5-af9f-cd5999c731de">

**Secondly:** this was the catalyst for finally refactoring the streamfield blocks to not auto-magically render wrapping divs that don't exist in any template, e.g. `.block-accordion_block`. 
While it seems like I'm adding a bunch of extra divs here, I'm essentially just renaming the divs that were already rendering, but with a bit more consistency/control. Now we don't need to style tags that have no corresponding html in the codebase.