### PR TITLE
Remove experimental view transitions meta tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,8 +7,6 @@
     <meta name="description" content="{% firstof self.search_description self.intro|default:''|striptags self.body_excerpt|default:''|striptags|truncatewords:40 self.title %}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta name="view-transition" content="same-origin">
-
     <script type="text/javascript"> window.staticRoot = "{% static 'dist/' %}"; </script>
 
     {% include "includes/favicons.html" %}


### PR DESCRIPTION
This is no longer how it works.

https://developer.chrome.com/docs/web-platform/view-transitions/cross-document#:~:text=Back%20when%20we%20were%20still%20experimenting%20with%20cross%2Ddocument%20view%20transitions%2C%20the%20opt%2Din%20was%20a%20meta%20tag