### PR TITLE
Change streamfield child selector

### DIFF
--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
 
-  & > :where(.block + .block) {
+  & > * + * {
     // Default `lg` space above each streamfield
     margin-block-start: var(--streamfield-space-lg);
 


### PR DESCRIPTION
Reverts part of a recent overhaul to streamfield block selection.

This didn't work in cases where the block was added to the page as a CMS fixed block, e.g. the person detail page:
<img width="1315" alt="Screenshot 2024-06-17 at 9 15 04 AM" src="https://github.com/springload/cdh-web/assets/1134713/6d0d2705-267d-4527-9ae9-9b0ab45ffc40">

So, reverting back to just selecting any direct child of the streamfield wrapper. Everything has a wrapper (either explicitly, or automatically like in the above tiles block case), so it should work fine.