### PR TITLE
Blog landing FED

### DIFF
--- a/cdhweb/static_src/components/ComponentsInit.tsx
+++ b/cdhweb/static_src/components/ComponentsInit.tsx
@@ -62,6 +62,13 @@ async function ComponentInit(
           /* webpackChunkName: "component-accordion" */
         ),
       );
+    case 'select-navigator':
+      return mountAsyncComponent(
+        import(
+          './SelectNavigator/SelectNavigator'
+          /* webpackChunkName: "component-select-navigator" */
+        ),
+      );
   }
 
   throw Error(

--- a/cdhweb/static_src/components/SelectNavigator/SelectNavigator.tsx
+++ b/cdhweb/static_src/components/SelectNavigator/SelectNavigator.tsx
@@ -1,0 +1,34 @@
+import type { InitComponent } from '../ComponentsInit';
+
+/**
+ * A `<select>` menu which navigates onchange, via a data-href on each `<option>`
+ */
+const initComponent: InitComponent = (componentEl) => {
+  const options = componentEl.querySelectorAll('option');
+
+  if (!options) {
+    console.log('No <option> items found. Aborting.');
+    return () => {
+      //
+    };
+  }
+
+  componentEl.addEventListener('change', (e: Event) => {
+    const target = e.target as HTMLSelectElement;
+    const selectedOption = target.options[target.selectedIndex];
+    const url = selectedOption.getAttribute('data-href');
+
+    if (!url) {
+      console.error('No `data-href` specified for selected option.');
+      return;
+    }
+
+    window.location.href = url;
+  });
+
+  return () => {
+    // Return a cleanup function. Nothing to do here.
+  };
+};
+
+export default initComponent;

--- a/cdhweb/static_src/global/components/simple-filter-bar.scss
+++ b/cdhweb/static_src/global/components/simple-filter-bar.scss
@@ -1,0 +1,32 @@
+/* 
+Simple filter `<select>` menu that can appear above a tiles list.
+Used on Events and Blog/News landing page.
+Layout code currently assumes there's only one label & select.
+*/
+
+.simple-filter-bar {
+  border-block-end: 1px solid var(--color-brand-100);
+  padding-block-end: 20px;
+  margin-block-end: 56px;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  @include sm {
+    justify-content: end;
+  }
+
+  :where(label) {
+    font-weight: bold;
+    font-size: px2rem(17);
+    line-height: 1.33;
+  }
+  :where(select) {
+    flex-grow: 1;
+
+    @include sm {
+      flex-grow: unset;
+    }
+  }
+}

--- a/cdhweb/static_src/global/elements/forms.scss
+++ b/cdhweb/static_src/global/elements/forms.scss
@@ -1,0 +1,15 @@
+select {
+  font: inherit;
+  appearance: none;
+  background-color: var(--color-white);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 16'%3E%3Cg fill-rule='evenodd' clip-rule='evenodd'%3E%3Cpath fill='var(--icon-accent-color, %2300edff)' d='m22.462 6.66-8.564 8.333-2.333-2.102 8.634-8.462 2.263 2.23Z' /%3E%3Cpath fill='var(--icon-color, %23414042)' d='m21.796 2.898-10.231 10-10.231-10L3.597.667l7.968 7.767L19.533.667l2.263 2.231Z' /%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px top 50%;
+  background-size: 20px;
+  padding-inline: 16px 38px;
+  border: 1px solid var(--color-grey-60);
+  border-radius: 8px;
+  font-size: px2rem(16);
+  font-weight: bold;
+  height: px2rem(40); // todo normalise once more forms built
+}

--- a/cdhweb/static_src/global/layout/page-layout.scss
+++ b/cdhweb/static_src/global/layout/page-layout.scss
@@ -25,12 +25,30 @@
 .page-layout--with-sidenav {
   // m = main content
   // s = side-nav
-
   @include xl {
     grid-template-areas: 's s s . m m m m m m m .';
   }
   @include xxxl {
     grid-template-areas: 's s . m m m m m m . . .';
+  }
+}
+
+// "wider" variants, for tile landing pages such as people events & blog/news.
+// Similar to above, but uses an extra col for content sometimes.
+.page-layout--without-sidenav-wider {
+  @include xl {
+    grid-template-areas: '. . m m m m m m m m m .';
+  }
+  @include xxxl {
+    grid-template-areas: '. . m m m m m m m m . .';
+  }
+}
+.page-layout--with-sidenav-wider {
+  @include xl {
+    grid-template-areas: 's s s . m m m m m m m .';
+  }
+  @include xxxl {
+    grid-template-areas: 's s . m m m m m m m . .';
   }
 }
 

--- a/cdhweb/static_src/styles.scss
+++ b/cdhweb/static_src/styles.scss
@@ -21,6 +21,7 @@
 
 // Elements
 @import './global/elements/typography';
+@import './global/elements/forms';
 @import './global/elements/page.scss';
 
 // Layout
@@ -73,6 +74,7 @@
 @import './global/components/newsletter.scss';
 @import './global/components/search-form.scss';
 @import './global/components/pagination.scss';
+@import './global/components/simple-filter-bar.scss';
 @import './global/components/footer.scss';
 
 // TODO delete migrated content styles once all migrated content is moved from

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,11 @@
 
     <script type="text/javascript"> window.staticRoot = "{% static 'dist/' %}"; </script>
 
+    <script>
+      document.documentElement.classList.remove('no-js');
+      document.documentElement.classList.add('js');
+    </script>
+
     {% include "includes/favicons.html" %}
 
     {% comment %}

--- a/templates/blog/blog_landing_page.html
+++ b/templates/blog/blog_landing_page.html
@@ -7,28 +7,45 @@
     {% include 'includes/breadcrumbs.html' with breadcrumbs=self.breadcrumbs current_page=self %}
     {% include 'includes/standard_hero.html' %}
 
+    <div class="content-width grid-standard page-layout page-layout--without-sidenav-wider">
+        <div class="page-layout__main-content">
 
-    <div class="archive-nav">
-        <a class="toggle">{{ page_title }} <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
-        <ul class="submenu">
-          {# include latest blogposts page link #}
-          {% url 'blog:list' slug=self.slug as latest_url %}
-          <li {% if request.path == latest_url %}class="current"{% endif %}><a href="{{ latest_url }}">Recent</a></li>
-          {% for archive_date in date_list %}
-          {% ifchanged %}<li>{{ archive_date.year }}</li>{% endifchanged %}
-              {% url 'blog:by-month' year=archive_date.year month=archive_date|date:"m" slug=self.slug as blog_url %}
-              <li {% if blog_url == request.path  %}class="current"{% endif %}>
-                  <a href="{{ blog_url }}">{{ archive_date|date:"F" }}</a></li>
-          {% endfor %}
-        </ul>
-      </div>
+          <div class="simple-filter-bar" class="u-no-js-hide">
+            <label for="blog-date-filter">
+              Show
+              <span class="sr-only">(Note: page will reload)</span>
+            </label>
+            <select id="blog-date-filter" data-component="select-navigator">
+              {% url 'blog:list' slug=self.slug as latest_url %}
+              <option data-href="{{ latest_url }}" {% if request.path == latest_url %}selected{% endif %}>Recent</option>
+              
+              {# Group months by year #}
+              {% for archive_date in date_list %}
+                {% ifchanged %}
+                  <optgroup label="{{ archive_date.year }}">
+                {% endifchanged %}
+              
+                {% url 'blog:by-month' year=archive_date.year month=archive_date|date:"m" slug=self.slug as blog_url %}
+                <option data-href="{{ blog_url }}" {% if blog_url == request.path  %}selected{% endif %}>{{ archive_date|date:"F" }}</option>
+                
+                {% ifchanged %}
+                  </optgroup>
+                {% endifchanged %}
+              {% endfor %}
+            </select>
+          </div>
 
-      {% for post in posts %}
-        {% include 'cdhpages/blocks/tile.html' with internal_page=post tile_type='internal_page_tile' %}
-    {% endfor %}
+          <div class="tiles__list">
+            {% for post in posts %}
+              {% include 'cdhpages/blocks/tile.html' with internal_page=post tile_type='internal_page_tile' %}
+            {% endfor %}
+          </div>
 
-    {% if is_paginated %}
-        {% include "includes/pagination.html" %}    
-    {% endif %}
+          {% if is_paginated %}
+            {% include "includes/pagination.html" %}    
+          {% endif %}
+        </div>
+      
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
Blog/news landing page styles, including the basic filtering. Uses the same pagination styles form search.

This PR also lays the layout style groundwork for the other tile-based landing pages that I'm about to work on: events and people, namely the basic filter dropdown and the wider content wrapper.

## Big
<img width="1585" alt="Screenshot 2024-06-21 at 10 10 40 AM" src="https://github.com/springload/cdh-web/assets/1134713/a7bdbbfd-5c29-4832-83dc-a5209c9aa7b3">

## Medium
<img width="741" alt="Screenshot 2024-06-21 at 10 11 05 AM" src="https://github.com/springload/cdh-web/assets/1134713/25b26dca-59da-4e09-90ff-a58965709060">

## Smol
<img width="336" alt="Screenshot 2024-06-21 at 10 11 20 AM" src="https://github.com/springload/cdh-web/assets/1134713/82022942-efe5-440e-9e3a-d3b29315dc79">

## Select:
<img width="243" alt="Screenshot 2024-06-21 at 10 22 04 AM" src="https://github.com/springload/cdh-web/assets/1134713/ac1d3382-7ad5-4340-9b93-c586c5c9f06f">
