### PR TITLE
Sidenav sticky offset

### DIFF
--- a/cdhweb/static_src/global/components/sidenav.scss
+++ b/cdhweb/static_src/global/components/sidenav.scss
@@ -16,7 +16,7 @@
   @include xl {
     max-width: px2rem(230);
     position: sticky;
-    top: 0;
+    top: 24px;
   }
 
   // Sidenav content styles


### PR DESCRIPTION
Sticky sidenav looked a bit crap, so added some breathing room. 

## Before:
<img width="1131" alt="Screenshot 2024-06-24 at 11 47 13 AM" src="https://github.com/springload/cdh-web/assets/1134713/959b0639-025d-4c0d-b0b1-ed6f1f0210ca">


## After:
<img width="1147" alt="Screenshot 2024-06-24 at 11 46 49 AM" src="https://github.com/springload/cdh-web/assets/1134713/500e2462-2aff-43d3-8083-ffc986b0c92a">
