### PR TITLE
Form style fix

### DIFF
--- a/cdhweb/static_src/global/elements/forms.scss
+++ b/cdhweb/static_src/global/elements/forms.scss
@@ -1,16 +1,13 @@
-:is(
-    input[type='text'],
-    input[type='email'],
-    input[type='password'],
-    input[type='number']
-  ) {
-  font: inherit;
-  width: 100%;
-  border: 1px solid var(--color-grey-60);
-  border-radius: 8px;
-  font-size: px2rem(16);
-  height: var(--form-field-height);
-  padding-inline: 16px;
+input {
+  &:where([type='text'], [type='email'], [type='password'], [type='number']) {
+    font: inherit;
+    width: 100%;
+    border: 1px solid var(--color-grey-60);
+    border-radius: 8px;
+    font-size: px2rem(16);
+    height: var(--form-field-height);
+    padding-inline: 16px;
+  }
 }
 
 select {


### PR DESCRIPTION
Newly-added global CSS rules in the elements layer was breaking styles for the search and newsletter forms, due to specificity (0,1,1):
<img width="922" alt="Screenshot 2024-06-27 at 9 13 18 AM" src="https://github.com/springload/cdh-web/assets/1134713/82944758-ede8-402f-8fbf-7bcb38785ca6">

Changed to (0,0,1), which fixes it:
<img width="858" alt="Screenshot 2024-06-27 at 9 20 41 AM" src="https://github.com/springload/cdh-web/assets/1134713/3199aadc-cf22-48de-b4bb-35d1a79a9fca">
