### PR TITLE
Fix migrated content layout

### DIFF
--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -18,6 +18,7 @@
             .block--table,
             .block--note,
             .block--paragraph,
+            .block--migrated-content,
             .block--pull-quote,
             .block--accordion:not(:has(> h2)),
             .block--video:not(:has(> h2))
@@ -38,6 +39,7 @@
         .block--accordion,
         .block--table,
         .block--paragraph,
+        .block--migrated-content,
         .block--download,
         .block--cta,
         .block--note,


### PR DESCRIPTION
While checking the new project page layout, I noticed migrated content spacing wasn't quite right. It should behave the same as the paragraph (rich text) component.