### PR TITLE
Improve visually hidden until focus code

### DIFF
--- a/cdhweb/static_src/global/mixins/visibility.scss
+++ b/cdhweb/static_src/global/mixins/visibility.scss
@@ -9,6 +9,22 @@
   clip: rect(0 0 0 0) !important;
 }
 
+@mixin visuallyHiddenUntilFocused {
+  // needs to be absolute *before* focus, otherwise can appear in the wrong place
+  position: absolute;
+
+  // ensure not obscured, e.g. by project filters
+  z-index: 2;
+
+  background-color: var(--color-white);
+  color: var(--color-black);
+  padding: 4px 8px;
+
+  &:not(:focus) {
+    @include visuallyHidden;
+  }
+}
+
 // Page initially loads with 'no-js' class on the body.
 // As soon as JS loads (via a script in the header),
 // it should replace that class with 'js'

--- a/cdhweb/static_src/global/utilities/show-hide.scss
+++ b/cdhweb/static_src/global/utilities/show-hide.scss
@@ -3,16 +3,7 @@
 }
 
 .sr-only-until-focused {
-  opacity: 0;
-  position: absolute;
-  background-color: var(--color-brand-100);
-  color: var(--color-black);
-  padding: 4px 8px;
-  z-index: 2; // ensure not obscured, e.g. by project filters
-
-  &:focus {
-    opacity: 1;
-  }
+  @include visuallyHiddenUntilFocused;
 }
 
 .u-hidden {


### PR DESCRIPTION
Noticed that the element in question was clickable:
<img width="332" alt="Screenshot 2024-07-04 at 10 29 33 AM" src="https://github.com/Princeton-CDH/cdh-web/assets/1134713/08f2b0eb-4d8a-4124-a193-d85132fdb968">

Since it should only show when it has focus, it should probably only be clickable then, too.

<img width="358" alt="Screenshot 2024-07-04 at 10 32 56 AM" src="https://github.com/Princeton-CDH/cdh-web/assets/1134713/e5ed7ba8-a174-4e43-9f88-4d754b0ebb33">

Probably the global skip link could use the same mixin, but this will do for now. Will think about adding this to the starterkit.