### PR TITLE
Exclude profiles from the People landing page listing

### DIFF
--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -807,7 +807,7 @@ class PeopleLandingPage(StandardHeroMixin, Page):
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
 
-        tiles = self.get_children().live()
+        tiles = self.get_children().not_type(Profile).live().public().specific()
         context["tiles"] = tiles
 
         return context

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -675,6 +675,14 @@ class PeopleCategoryPage(BaseLandingPage, SidebarNavigationMixin, RoutablePageMi
         }
 
         people = category_mapping[self.category]()
+        people = people.prefetch_related(
+            "image",
+            "image__renditions",
+            "profile",
+            "positions",
+            "positions__title",
+            "profile__image",
+        )
 
         for person in people:
             person.position = person.get_position_for_tile(self.category)


### PR DESCRIPTION
As a migration step, we have moved the existing people pages, so that we're relying on parent-child relationships for category pages, rather than [views mounted over the top of page paths](https://github.com/Princeton-CDH/cdh-web/blob/main/cdhweb/people/views.py).

However, people can belong to more than one category, for example Brian Kernighan belongs on both the [Executive Committee](https://cdh.princeton.edu/people/executive-committee/) and the [(Past) Staff ](https://cdh.princeton.edu/people/staff/)pages, so we can't have the profiles existing under the specific categories.

As such, the person-profiles are set up to be homed directly underneath the PeopleLandingPage, but should not be listed alongside the PeopleCategoryPages that _do_ belong there. While we could restrict the child listing by type, it seems safer (in case we eventually add another allowed child-type for example) that we exclude the profiles from that listing, as they already have a suitable display location as grandchildren

Also do some prefetching to optimise pages with a larger number of people