### PR TITLE
Remove test references to defunct PageIntro model

### DIFF
--- a/cdhweb/events/tests/test_templates.py
+++ b/cdhweb/events/tests/test_templates.py
@@ -3,8 +3,6 @@ from django.urls import reverse
 from django.utils.timezone import localtime
 from pytest_django.asserts import assertContains, assertNotContains
 
-from cdhweb.pages.models import PageIntro
-
 
 class TestEventDetailTemplate:
     def test_event_title(self, client, workshop):

--- a/cdhweb/pages/tests/test_context_processors.py
+++ b/cdhweb/pages/tests/test_context_processors.py
@@ -1,4 +1,0 @@
-import pytest
-from wagtail.models import Page
-
-from cdhweb.pages.models import LinkPage, PageIntro

--- a/cdhweb/people/tests/test_pages.py
+++ b/cdhweb/people/tests/test_pages.py
@@ -11,7 +11,7 @@ from wagtail.test.utils import WagtailPageTestCase
 from wagtail.test.utils.form_data import rich_text
 
 from cdhweb.blog.models import Author, BlogPost
-from cdhweb.pages.models import LinkPage, PageIntro
+from cdhweb.pages.models import LinkPage
 from cdhweb.people.models import PeopleLandingPageArchived, Person, Profile
 
 
@@ -119,16 +119,3 @@ class TestProfilePage(WagtailPageTestCase):
     def test_child_pages(self):
         """no allowed children"""
         self.assertAllowedSubpageTypes(Profile, [])
-
-
-@pytest.mark.django_db
-class TestPageIntro:
-    def test_str(self):
-        root = Page.objects.get(title="Root")
-        link_page = LinkPage(title="Students")
-        root.add_child(instance=link_page)
-        intro = PageIntro.objects.create(
-            page=link_page, paragraph="<p>We have great students</p>"
-        )
-
-        assert str(intro) == link_page.title

--- a/cdhweb/projects/tests/test_templates.py
+++ b/cdhweb/projects/tests/test_templates.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
 
-from cdhweb.pages.models import LinkPage, PageIntro, RelatedLinkType
+from cdhweb.pages.models import RelatedLinkType
 from cdhweb.pages.tests.conftest import to_streamfield_safe
 from cdhweb.projects.models import ProjectRelatedLink
 

--- a/docker/application/Dockerfile
+++ b/docker/application/Dockerfile
@@ -29,9 +29,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip3 install -r docker/requirements.txt && \
     pip3 install -r requirements/prod.txt
 
-
-
-
 RUN adduser --system www -u 1000 && chown -R www /app
 
 


### PR DESCRIPTION
These were causing issues with the *collection* step of the test run, so were obscuring/preventing the actual test-run