### PR TITLE
Remove reference to non-existant template in 500 page

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script type="text/javascript"> window.staticRoot = "{% static 'dist/' %}"; </script>
-    {% include "core/includes/icons.html" %}
 
   </head>
   <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
Additionally, this page doesn't really need to look-nice, as the Library load-balancer returns it own error response that masks this page