### PR TITLE
Remove old people-category views from URLs

### DIFF
--- a/cdhweb/people/urls.py
+++ b/cdhweb/people/urls.py
@@ -1,18 +1,9 @@
 from django.urls import path
-from django.views.generic.base import RedirectView
 
 from cdhweb.people import views
 
 app_name = "people"
 urlpatterns = [
-    path("staff/", views.StaffListView.as_view(), name="staff"),
-    path("students/", views.StudentListView.as_view(), name="students"),
-    path("affiliates/", views.AffiliateListView.as_view(), name="affiliates"),
-    path("executive-committee/", views.ExecListView.as_view(), name="exec-committee"),
     # speakers list was deleted; serve 410 gone
     path("speakers/", views.speakerlist_gone),
-    # redirect from /people/faculty -> /people/affiliates
-    path("faculty/", RedirectView.as_view(url="/people/affiliates/", permanent=True)),
-    # redirect from /people/postdocs -> /people/staff
-    path("postdocs/", RedirectView.as_view(url="/people/staff/", permanent=True)),
 ]


### PR DESCRIPTION
These were overriding the pages added in content loading

Client report:
https://springload.slack.com/archives/C06P11WJD5Z/p1721678496231959