### PR TITLE
Switch blog page listing to show 12-per-page

### DIFF
--- a/cdhweb/blog/models.py
+++ b/cdhweb/blog/models.py
@@ -233,7 +233,7 @@ class BlogLinkPageArchived(LinkPage):
 class BlogLandingPage(StandardHeroMixinNoImage, RoutablePageMixin, Page):
     """Container page that defines where Event pages can be created."""
 
-    page_size = 15
+    page_size = 12
     template_name = "blog/blog_landing_page.html"
 
     content_panels = StandardHeroMixinNoImage.content_panels


### PR DESCRIPTION
The blog page can present as 1-,2-,3- or 4- across so 12 factors much better, and we don't end up with a partial row