### PR TITLE
Restore RSS feed functionality

### DIFF
--- a/cdhweb/blog/models.py
+++ b/cdhweb/blog/models.py
@@ -1,3 +1,5 @@
+import bleach
+
 from django.core.paginator import Paginator
 from django.db import models
 from django.shortcuts import get_object_or_404
@@ -223,6 +225,30 @@ class BlogPost(BasePage, ClusterableModel):
         if self.featured:
             urls[0]["priority"] = 0.6  # default is 0.5; slight increase
         return urls
+
+    @cached_property
+    def feeds_description(self):
+        """
+        Plaintext description for RSS and Atom feeds
+
+        Short description, then description, then looks for
+        the first paragraph of the text
+        """
+        if self.short_description.strip():
+            return self.short_description.strip()
+
+        description = bleach.clean(self.description, tags=[], strip=True)
+        # Fall back to the first block of the page if
+        # there's no description, once the HTML is removed
+        if not description:
+            # Iterate over blocks and use content from first paragraph content
+            for block in self.body:
+                if block.block_type == "paragraph":
+                    # Return the very first block
+                    description = block
+                    return bleach.clean(description, tags=[], strip=True)
+
+        return ""  # We're really out of ideas, prevent a "None"
 
 
 class BlogLinkPageArchived(LinkPage):

--- a/cdhweb/blog/views.py
+++ b/cdhweb/blog/views.py
@@ -8,7 +8,7 @@ class RssBlogPostFeed(Feed):
     """Blog post RSS feed"""
 
     title = "Center for Digital Humanities @ Princeton University Updates"
-    link = "/updates/"
+    link = "/blog/"  # Not technically correct, but currently best-match
     description = "Updates and news on work from the Center for Digital Humanities @ Princeton University"
 
     def items(self):
@@ -21,7 +21,7 @@ class RssBlogPostFeed(Feed):
 
     def item_description(self, item):
         """blog post description, for feed content"""
-        return item.get_description()
+        return item.feeds_description
 
     def item_link(self, item):
         """absolute link to blog post"""


### PR DESCRIPTION
The resolution and treatment of the feeds_description text _roughly_ follows the existing pattern as can be seen at
https://github.com/Princeton-CDH/cdh-web/blob/bfd904f78a98a49c499acac89a3e76a56d6c778b/cdhweb/pages/models.py#L153-L179