### PR TITLE
Make blog post redirect view a permanent / 301 redirect

### DIFF
--- a/cdhweb/blog/views.py
+++ b/cdhweb/blog/views.py
@@ -67,6 +67,7 @@ class AtomBlogPostFeed(RssBlogPostFeed):
 
 class BlogPostRedirectView(RedirectView):
     pattern_name = "blog-detail"
+    permanent = True
     
     def get_redirect_url(self, *args, **kwargs):
         post = get_object_or_404(BlogPost, slug=kwargs["slug"])


### PR DESCRIPTION
Thanks for adding the blog post redirect view. It should be a permanent redirect (301, not 302) - I think this change is all that's needed.