### PR TITLE
Handle blog post authors without profile urls

### DIFF
--- a/templates/includes/blog_hero.html
+++ b/templates/includes/blog_hero.html
@@ -14,7 +14,7 @@
                 <h2 class="sr-only">Authors</h2>
                 <ul>
                     {% for author in page.authors.all %}
-                        <li><a href="{{ author.person.profile_url }}">{{ author.person }}</a></li>
+                        <li>{% if author.person.profile_url %}<a href="{{ author.person.profile_url }}">{{ author.person }}</a>{% else %}{{ author.person }}{% endif %}</li>
                     {% endfor %}
                 </ul>
             </div>


### PR DESCRIPTION
It's possible for an author not to have a valid profile url, in which case you get an author link of blog post url followed by the text "None" - example here: https://cdh-beta.princeton.edu/blog/2024/07/13/senior-thesis-spotlight-fernando-aviles-garcia-used-artificial-intelligence-to-analyze-dantes-divine-comedy/

I think this template code should do what is needed but I'm just using the online github editor so please confirm.