### PR TITLE
Swap navigation queries from exists()->first() to just first()

### DIFF
--- a/cdhweb/pages/templatetags/core_tags.py
+++ b/cdhweb/pages/templatetags/core_tags.py
@@ -19,21 +19,21 @@ def site_footer(context):
     Returns the site footer data.
     """
     # Get footer items
-    footers = Footer.objects.prefetch_related(
+    footer = Footer.objects.prefetch_related(
         "contact_links", "useful_links", "imprint_links"
-    )
+    ).first()
 
     data = {
         "request": context["request"],
         "site_search": context["site_search"],
         "SW_VERSION": context["SW_VERSION"],
     }
-    if footers.exists():
-        contact_links = footers.first().contact_links.all()
-        social_media_links = footers.first().social_media_links.all()
-        physical_address = footers.first().address
-        useful_links = footers.first().useful_links.all()
-        imprint_links = footers.first().imprint_links.all()
+    if footer:
+        contact_links = footer.contact_links.all()
+        social_media_links = footer.social_media_links.all()
+        physical_address = footer.address
+        useful_links = footer.useful_links.all()
+        imprint_links = footer.imprint_links.all()
 
         data |= {
             "contact_links": contact_links,
@@ -77,9 +77,9 @@ def _get_primary_nav_items():
     l1_menu_items = []
     primary_nav = PrimaryNavigation.objects.prefetch_related(
         "l1_items", "l1_items__l2_items"
-    )
-    if primary_nav.exists():
-        l1_menu_items = primary_nav.first().l1_items.all()
+    ).first()
+    if primary_nav:
+        l1_menu_items = primary_nav.l1_items.all()
     return l1_menu_items
 
 
@@ -132,9 +132,9 @@ def _get_secondary_nav_items():
     Get secondary nav items
     """
     items = []
-    secondary_nav = SecondaryNavigation.objects.prefetch_related("items")
-    if secondary_nav.exists():
-        items = secondary_nav.first().items.all()
+    secondary_nav = SecondaryNavigation.objects.prefetch_related("items").first()
+    if secondary_nav:
+        items = secondary_nav.items.all()
 
     return items
 
@@ -143,10 +143,10 @@ def _get_secondary_nav_cta_button():
     """
     Get secondary nav cta button
     """
-    secondary_nav = SecondaryNavigation.objects.prefetch_related("cta_button")
+    secondary_nav = SecondaryNavigation.objects.prefetch_related("cta_button").first()
 
-    if secondary_nav.exists():
-        return secondary_nav.first().cta_button.all()
+    if secondary_nav:
+        return secondary_nav.cta_button.all()
     return []
 
 
@@ -158,9 +158,9 @@ def primary_navigation():
     l1_menu_items = []
     main_menu = PrimaryNavigation.objects.prefetch_related(
         "l1_items", "l1_items__l2_items"
-    )
-    if main_menu.exists():
-        l1_menu_items = main_menu.first().l1_items.all()
+    ).first()
+    if main_menu:
+        l1_menu_items = main_menu.l1_items.all()
 
         data = {
             "l1_menu_items": l1_menu_items,
@@ -177,10 +177,12 @@ def secondary_navigation():
     """
 
     items = []
-    secondary_menu = SecondaryNavigation.objects.prefetch_related("items", "cta_button")
-    if secondary_menu.exists():
-        items = secondary_menu.first().items.all()
-        cta_button = secondary_menu.first().cta_button.first()
+    secondary_menu = SecondaryNavigation.objects.prefetch_related(
+        "items", "cta_button"
+    ).first()
+    if secondary_menu:
+        items = secondary_menu.items.all()
+        cta_button = secondary_menu.cta_button.first()
 
         data = {
             "secondary_nav_items": items,

--- a/templates/includes/event_hero.html
+++ b/templates/includes/event_hero.html
@@ -1,17 +1,17 @@
 {% load wagtailcore_tags wagtailimages_tags l10n %}
 
 <div class="event-hero content-width grid-standard">
-    
+
     <div class="event-hero__text">
         <h1>{{ self.title}}</h1>
-    
+
         <p class="event-hero__date">
             {# Display date differently depending on if it spans multiple days #}
             {% if self.start_time.date == self.end_time.date %}
-                <time datetime="{{ self.start_time|date:'c' }}">{{ self.start_time|date:"M d g:i a" }}</time> – 
+                <time datetime="{{ self.start_time|date:'c' }}">{{ self.start_time|date:"M d g:i a" }}</time> –
                 <time datetime="{{ self.end_time|date:'c' }}">{{ self.end_time|date:"g:i a" }}</time>
             {% else %}
-                <time datetime="{{ self.start_time|date:'c' }}">{{ self.start_time|date:"M d g:i a" }}</time> – 
+                <time datetime="{{ self.start_time|date:'c' }}">{{ self.start_time|date:"M d g:i a" }}</time> –
                 <time datetime="{{ self.end_time|date:'c' }}">{{ self.end_time|date:"M d g:i a" }}</time>
             {% endif %}
         </p>
@@ -22,13 +22,13 @@
         {# Much of this schema is ported over from the old event template #}
         {% if self.location %}
             <div
-                class="event-hero__location" 
+                class="event-hero__location"
                 property="schema:location"
                 typeof="{% if self.location.name %}schema:VirtualLocation{% else %}schema:Place{% endif %}"
             >
                 <span property="schema:name">{{ self.location.name }}</span>
                 {% if not self.location.name == "Virtual" %}
-                    <div 
+                    <div
                         property="schema:address"
                         {% if self.location.name == self.location.address %}style="display:none"{% endif %}
                     >
@@ -54,7 +54,7 @@
         {% if self.tags.all %}
             <div class="tag-list">
                 {% for tag in self.tags.all %}
-                    <div class="tag">{{ tag }}</div>    
+                    <div class="tag">{{ tag }}</div>
                 {% endfor %}
             </div>
         {% endif %}
@@ -62,7 +62,7 @@
 
     {% if self.image %}
         <figure class="event-hero__img">
-            {% comment %}    
+            {% comment %}
                 All are cropped to a 16:9 ratio. This differs from design, as discussed.
                 If changing this by image rendition, update aspect-ratio in the CSS instead
                 of via inline style.
@@ -76,12 +76,12 @@
                 <source srcset="{{ img_sm.url }}" media="(min-width: 500px)">
                 <source srcset="{{ img_xl.url }}" media="(min-width: 1200px)">
                 <img
-                    src="{{ img_base.url }}" 
+                    src="{{ img_base.url }}"
                     alt="{{ self.alt_text|default:img_base.alt }}"
                     style="aspect-ratio: {{ img_base.width|unlocalize }} / {{ img_base.height|unlocalize }}"
                 />
             </picture>
-            
+
             {% if self.caption or self.credit %}
                 <figcaption class="sk-image__text-content">
                     {% if self.credit %}
@@ -97,7 +97,7 @@
                 </figcaption>
             {% endif %}
         </figure>
-            
+
     {% endif %}
-    
+
 </div>

--- a/templates/includes/event_hero.html
+++ b/templates/includes/event_hero.html
@@ -45,7 +45,11 @@
                 <h2 class="sr-only">Speakers</h2>
                 <ul>
                     {% for speaker in page.speakers.all %}
-                        <li>{{ speaker.person }}</li>
+                        {% if speaker.person.profile %}
+                            <li><a href="{% pageurl speaker.person.profile %}">{{ speaker.person }}</a></li>
+                        {% else %}
+                            <li>{{ speaker.person }}</li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
             </div>


### PR DESCRIPTION
This should reduce the number of queries we make on two fronts -- first, the
exists does a `select 1 ...`, which doesn't contribute to the cache, and so the
`.first()` call then makes a second query to get actual data. There were also a
bunch of places where we were repeatedly calling `first` to get a related item,
which might have been doing multiple queries -- but this way is also a but more
readable